### PR TITLE
feat: UX improvements — theme toggle, Notion caching, a11y, loading states

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+BASE_URL=value
+NOTION_ACCESS_TOKEN=value
+NOTION_DATABASE_GEARS_ID=value
+NOTION_DATABASE_CONTENT_ID=value
+NOTION_PAGE_HOME_ID=value
+NOTION_PAGE_ABOUT_ID=value
+NOTION_PAGE_WORK_ID=value
+NOTION_PAGE_BLOG_ID=value
+NOTION_PAGE_GEARS_ID=value
+# Optional: rich_text property name on the content DB (exact URL slug per row). When set, slug lookups use one filtered query instead of scanning pages.
+# NOTION_SLUG_PROPERTY=Slug

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env
+.env*.local
 
 # vercel
 .vercel

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,16 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "images.notionusercontent.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "prod-files-secure.s3.us-west-2.amazonaws.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "*.amazonaws.com",
       },
       {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
-    "moment": "^2.30.1",
     "next": "16.2.4",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       lucide-react:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.4)
-      moment:
-        specifier: ^2.30.1
-        version: 2.30.1
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2888,9 +2885,6 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  moment@2.30.1:
-    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6691,8 +6685,6 @@ snapshots:
       brace-expansion: 1.1.14
 
   minimist@1.2.8: {}
-
-  moment@2.30.1: {}
 
   ms@2.1.3: {}
 

--- a/src/app/_components/about-content.tsx
+++ b/src/app/_components/about-content.tsx
@@ -1,0 +1,9 @@
+import ContentSection from "@/sections/content";
+import { getPageBlocks } from "@/services/notion";
+import { formatBlockWithChildren } from "@/utils/formatter";
+
+export async function AboutContent() {
+  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_ABOUT_ID!);
+  const pageContent = formatBlockWithChildren(pageBlocks);
+  return <ContentSection blocks={pageContent} />;
+}

--- a/src/app/_components/about-hero.tsx
+++ b/src/app/_components/about-hero.tsx
@@ -1,0 +1,17 @@
+import Hero from "@/sections/hero";
+import { getPageData } from "@/services/notion";
+import { formatPageMetadata } from "@/utils/formatter";
+
+export async function AboutHero() {
+  const page = await getPageData(process.env.NOTION_PAGE_ABOUT_ID!);
+  const pageMetadata = formatPageMetadata(page);
+
+  return (
+    <Hero
+      title={pageMetadata.title}
+      description={pageMetadata.description}
+      thumbnail={pageMetadata.thumbnail}
+      size="small"
+    />
+  );
+}

--- a/src/app/_components/blog-hero.tsx
+++ b/src/app/_components/blog-hero.tsx
@@ -1,0 +1,17 @@
+import Hero from "@/sections/hero";
+import { getPageData } from "@/services/notion";
+import { formatPageMetadata } from "@/utils/formatter";
+
+export async function BlogHero() {
+  const page = await getPageData(process.env.NOTION_PAGE_BLOG_ID!);
+  const pageMetadata = formatPageMetadata(page);
+
+  return (
+    <Hero
+      title={pageMetadata.title}
+      description={pageMetadata.description}
+      thumbnail={pageMetadata.thumbnail}
+      size="small"
+    />
+  );
+}

--- a/src/app/_components/blog-posts.tsx
+++ b/src/app/_components/blog-posts.tsx
@@ -1,0 +1,16 @@
+import PostsSection from "@/sections/posts";
+import { getDatabasePages } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+
+export async function BlogPosts() {
+  const blogPages = await getDatabasePages(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Blog",
+    20,
+  );
+  const blogPostMetadata = formatPostMetadata(blogPages);
+
+  return (
+    <PostsSection title="Latest Posts" id="blog" posts={blogPostMetadata} />
+  );
+}

--- a/src/app/_components/home-hero.tsx
+++ b/src/app/_components/home-hero.tsx
@@ -1,0 +1,26 @@
+import { Typography } from "@/components/typography";
+import Hero from "@/sections/hero";
+import { getPageData } from "@/services/notion";
+import { formatPageMetadata } from "@/utils/formatter";
+
+export async function HomeHero() {
+  const page = await getPageData(process.env.NOTION_PAGE_HOME_ID!);
+  const pageMetadata = formatPageMetadata(page);
+
+  return (
+    <Hero
+      title={pageMetadata.title}
+      description={pageMetadata.description}
+      bottom={
+        <div className="flex w-full items-center justify-between gap-2">
+          <Typography className="line-clamp-1 break-all font-bold text-muted-foreground">
+            {pageMetadata.role}
+          </Typography>
+          <Typography className="line-clamp-1 break-all font-bold text-muted-foreground">
+            📍 {pageMetadata.location}
+          </Typography>
+        </div>
+      }
+    />
+  );
+}

--- a/src/app/_components/home-posts.tsx
+++ b/src/app/_components/home-posts.tsx
@@ -1,0 +1,21 @@
+import PostsSection from "@/sections/posts";
+import { getDatabasePages } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+
+export async function HomePosts() {
+  const blogPages = await getDatabasePages(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Blog",
+    4,
+  );
+  const blogPostMetadata = formatPostMetadata(blogPages);
+
+  return (
+    <PostsSection
+      title="Latest Posts"
+      href="/blog"
+      id="blog"
+      posts={blogPostMetadata}
+    />
+  );
+}

--- a/src/app/_components/home-projects.tsx
+++ b/src/app/_components/home-projects.tsx
@@ -1,0 +1,22 @@
+import ProjectsSection from "@/sections/projects";
+import { getDatabasePages } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+
+export async function HomeProjects() {
+  const projectPages = await getDatabasePages(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Project",
+    3,
+  );
+  const projectPostMetadata = formatPostMetadata(projectPages);
+
+  return (
+    <ProjectsSection
+      title="Latest Projects"
+      href="/work"
+      id="work"
+      posts={projectPostMetadata}
+      className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(240px,1fr))] justify-center gap-5"
+    />
+  );
+}

--- a/src/app/_components/work-body.tsx
+++ b/src/app/_components/work-body.tsx
@@ -1,0 +1,9 @@
+import ContentSection from "@/sections/content";
+import { getPageBlocks } from "@/services/notion";
+import { formatBlockWithChildren } from "@/utils/formatter";
+
+export async function WorkBody() {
+  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_WORK_ID!);
+  const pageContent = formatBlockWithChildren(pageBlocks);
+  return <ContentSection blocks={pageContent} />;
+}

--- a/src/app/_components/work-hero.tsx
+++ b/src/app/_components/work-hero.tsx
@@ -1,0 +1,16 @@
+import Hero from "@/sections/hero";
+import { getPageData } from "@/services/notion";
+import { formatPageMetadata } from "@/utils/formatter";
+
+export async function WorkHero() {
+  const page = await getPageData(process.env.NOTION_PAGE_WORK_ID!);
+  const pageMetadata = formatPageMetadata(page);
+
+  return (
+    <Hero
+      title={pageMetadata.title}
+      description={pageMetadata.description}
+      size="small"
+    />
+  );
+}

--- a/src/app/_components/work-projects.tsx
+++ b/src/app/_components/work-projects.tsx
@@ -1,0 +1,21 @@
+import ProjectsSection from "@/sections/projects";
+import { getDatabasePages } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+
+export async function WorkProjects() {
+  const projectPages = await getDatabasePages(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Project",
+    20,
+  );
+  const projectPostMetadata = formatPostMetadata(projectPages);
+
+  return (
+    <ProjectsSection
+      title="Latest Projects"
+      id="work"
+      posts={projectPostMetadata}
+      className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(300px,1fr))] justify-center gap-5"
+    />
+  );
+}

--- a/src/app/about/loading.tsx
+++ b/src/app/about/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from "@/components/skeletons/page-skeleton";
+
+export default function AboutLoading() {
+  return <PageSkeleton />;
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,6 +4,8 @@ import { Suspense } from "react";
 import { AboutContent } from "../_components/about-content";
 import { AboutHero } from "../_components/about-hero";
 
+export const revalidate = 10;
+
 export default function AboutPage() {
   return (
     <>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,25 +1,18 @@
-import ContentSection from "@/sections/content";
-import Hero from "@/sections/hero";
-import { getPageBlocks, getPageData } from "@/services/notion";
-import { formatBlockWithChildren, formatPageMetadata } from "@/utils/formatter";
-import { Fragment } from "react";
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { Suspense } from "react";
+import { AboutContent } from "../_components/about-content";
+import { AboutHero } from "../_components/about-hero";
 
-export default async function AboutPage() {
-  const page = await getPageData(process.env.NOTION_PAGE_ABOUT_ID!);
-  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_ABOUT_ID!);
-
-  const pageMetadata = formatPageMetadata(page);
-  const pageContent = formatBlockWithChildren(pageBlocks);
-
+export default function AboutPage() {
   return (
-    <Fragment>
-      <Hero
-        title={pageMetadata.title}
-        description={pageMetadata.description}
-        thumbnail={pageMetadata.thumbnail}
-        size="small"
-      />
-      <ContentSection blocks={pageContent} />
-    </Fragment>
+    <>
+      <Suspense fallback={<HeroSkeleton size="small" showThumbnail />}>
+        <AboutHero />
+      </Suspense>
+      <Suspense fallback={<ContentSectionSkeleton />}>
+        <AboutContent />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/blog/[slug]/_components/blog-post-body.tsx
+++ b/src/app/blog/[slug]/_components/blog-post-body.tsx
@@ -1,0 +1,22 @@
+import ContentSection from "@/sections/content";
+import { getDatabasePageBySlug, getPageBlocks } from "@/services/notion";
+import { formatBlockWithChildren } from "@/utils/formatter";
+import { notFound } from "next/navigation";
+
+export async function BlogPostBody({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const found = await getDatabasePageBySlug(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Blog",
+    slug,
+  );
+  if (!found) notFound();
+
+  const pageBlocks = await getPageBlocks(found.page.id);
+  const pageContent = formatBlockWithChildren(pageBlocks);
+  return <ContentSection blocks={pageContent} />;
+}

--- a/src/app/blog/[slug]/_components/blog-post-hero.tsx
+++ b/src/app/blog/[slug]/_components/blog-post-hero.tsx
@@ -1,0 +1,38 @@
+import { HeadingTop } from "@/components/heading-top";
+import Hero from "@/sections/hero";
+import { getDatabasePageBySlug } from "@/services/notion";
+import { formatPostDateFull } from "@/utils/formatter";
+import { notFound } from "next/navigation";
+
+export async function BlogPostHero({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const found = await getDatabasePageBySlug(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Blog",
+    slug,
+  );
+  if (!found) notFound();
+
+  const { metadata } = found;
+  const dateLabel = formatPostDateFull(metadata.published_date);
+
+  return (
+    <Hero
+      top={
+        <HeadingTop
+          title={metadata.title}
+          date={dateLabel}
+          postsPath="/blog"
+        />
+      }
+      title={metadata.title}
+      description={metadata.description}
+      thumbnail={metadata.thumbnail}
+      size="small"
+    />
+  );
+}

--- a/src/app/blog/[slug]/_components/blog-post-hero.tsx
+++ b/src/app/blog/[slug]/_components/blog-post-hero.tsx
@@ -26,6 +26,7 @@ export async function BlogPostHero({
         <HeadingTop
           title={metadata.title}
           date={dateLabel}
+          dateTime={metadata.published_date}
           postsPath="/blog"
         />
       }

--- a/src/app/blog/[slug]/loading.tsx
+++ b/src/app/blog/[slug]/loading.tsx
@@ -1,0 +1,11 @@
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+
+export default function BlogPostLoading() {
+  return (
+    <>
+      <HeroSkeleton showThumbnail showTopNav size="small" />
+      <ContentSectionSkeleton />
+    </>
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,19 +1,11 @@
-import { HeadingTop } from "@/components/heading-top";
-import ContentSection from "@/sections/content";
-import Hero from "@/sections/hero";
-import {
-  getDatabasePageBySlug,
-  getDatabasePages,
-  getPageBlocks,
-} from "@/services/notion";
-import {
-  formatBlockWithChildren,
-  formatPostDateFull,
-  formatPostMetadata,
-} from "@/utils/formatter";
-import { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { Fragment } from "react";
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { getDatabasePages, getDatabasePageBySlug } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { BlogPostBody } from "./_components/blog-post-body";
+import { BlogPostHero } from "./_components/blog-post-hero";
 
 const SLUG_PAGE_LIMIT = 100;
 
@@ -43,41 +35,19 @@ export async function generateMetadata({
   };
 }
 
-export default async function BlogPostPage({
+export default function BlogPostPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  const { slug } = await params;
-  const found = await getDatabasePageBySlug(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Blog",
-    slug,
-  );
-  if (!found) notFound();
-
-  const { metadata } = found;
-  const pageBlocks = await getPageBlocks(found.page.id);
-  const pageContent = formatBlockWithChildren(pageBlocks);
-
-  const dateLabel = formatPostDateFull(metadata.published_date);
-
   return (
-    <Fragment>
-      <Hero
-        top={
-          <HeadingTop
-            title={metadata.title}
-            date={dateLabel}
-            postsPath="/blog"
-          />
-        }
-        title={metadata.title}
-        description={metadata.description}
-        thumbnail={metadata.thumbnail}
-        size="small"
-      />
-      <ContentSection blocks={pageContent} />
-    </Fragment>
+    <>
+      <Suspense fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}>
+        <BlogPostHero params={params} />
+      </Suspense>
+      <Suspense fallback={<ContentSectionSkeleton />}>
+        <BlogPostBody params={params} />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { Suspense } from "react";
 import { BlogPostBody } from "./_components/blog-post-body";
 import { BlogPostHero } from "./_components/blog-post-hero";
 
+export const revalidate = 10;
+
 const SLUG_PAGE_LIMIT = 100;
 
 export async function generateStaticParams() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
-import { getDatabasePages, getDatabasePageBySlug } from "@/services/notion";
+import { getDatabasePageBySlug, getDatabasePages } from "@/services/notion";
 import { formatPostMetadata } from "@/utils/formatter";
 import type { Metadata } from "next";
 import { Suspense } from "react";
@@ -42,7 +42,9 @@ export default function BlogPostPage({
 }) {
   return (
     <>
-      <Suspense fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}>
+      <Suspense
+        fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}
+      >
         <BlogPostHero params={params} />
       </Suspense>
       <Suspense fallback={<ContentSectionSkeleton />}>

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
-import { getDatabasePageBySlug, getDatabasePages } from "@/services/notion";
-import { formatPostMetadata } from "@/utils/formatter";
+import {
+  getAllPublishedSlugsForStaticParams,
+  getDatabasePageBySlug,
+} from "@/services/notion";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { BlogPostBody } from "./_components/blog-post-body";
@@ -9,12 +11,9 @@ import { BlogPostHero } from "./_components/blog-post-hero";
 
 export const revalidate = 10;
 
-const SLUG_PAGE_LIMIT = 100;
-
 export async function generateStaticParams() {
   const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
-  const pages = await getDatabasePages(databaseId, "Blog", SLUG_PAGE_LIMIT);
-  return formatPostMetadata(pages).map((p) => ({ slug: p.slug }));
+  return getAllPublishedSlugsForStaticParams(databaseId, "Blog");
 }
 
 export async function generateMetadata({

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,11 @@
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
+
+export default function BlogLoading() {
+  return (
+    <>
+      <HeroSkeleton size="small" showThumbnail />
+      <PostsSectionSkeleton rowCount={6} />
+    </>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -4,6 +4,8 @@ import { Suspense } from "react";
 import { BlogHero } from "../_components/blog-hero";
 import { BlogPosts } from "../_components/blog-posts";
 
+export const revalidate = 10;
+
 export default function BlogPage() {
   return (
     <>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,11 +7,7 @@ import { BlogPosts } from "../_components/blog-posts";
 export default function BlogPage() {
   return (
     <>
-      <Suspense
-        fallback={
-          <HeroSkeleton size="small" showThumbnail />
-        }
-      >
+      <Suspense fallback={<HeroSkeleton size="small" showThumbnail />}>
         <BlogHero />
       </Suspense>
       <Suspense fallback={<PostsSectionSkeleton rowCount={6} />}>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,29 +1,22 @@
-import Hero from "@/sections/hero";
-import PostsSection from "@/sections/posts";
-import { getDatabasePages, getPageData } from "@/services/notion";
-import { formatPageMetadata, formatPostMetadata } from "@/utils/formatter";
-import { Fragment } from "react";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
+import { Suspense } from "react";
+import { BlogHero } from "../_components/blog-hero";
+import { BlogPosts } from "../_components/blog-posts";
 
-export default async function BlogPage() {
-  const page = await getPageData(process.env.NOTION_PAGE_BLOG_ID!);
-  const pageMetadata = formatPageMetadata(page);
-
-  const blogPages = await getDatabasePages(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Blog",
-    20,
-  );
-  const blogPostMetadata = formatPostMetadata(blogPages);
-
+export default function BlogPage() {
   return (
-    <Fragment>
-      <Hero
-        title={pageMetadata.title}
-        description={pageMetadata.description}
-        thumbnail={pageMetadata.thumbnail}
-        size="small"
-      />
-      <PostsSection title="Latest Posts" id="blog" posts={blogPostMetadata} />
-    </Fragment>
+    <>
+      <Suspense
+        fallback={
+          <HeroSkeleton size="small" showThumbnail />
+        }
+      >
+        <BlogHero />
+      </Suspense>
+      <Suspense fallback={<PostsSectionSkeleton rowCount={6} />}>
+        <BlogPosts />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -131,6 +131,51 @@ body {
   html {
     @apply font-sans;
   }
+
+  :focus-visible {
+    @apply rounded-sm outline-2 outline-offset-2 outline-ring;
+  }
+}
+
+/*
+ * Skip link: visually hidden (not merely translated) until :focus-visible.
+ * Percent translateY does not move a one-line link off-screen.
+ */
+.skip-link {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+.skip-link:focus-visible {
+  position: fixed;
+  left: 1rem;
+  top: 1rem;
+  z-index: 9999;
+  width: max-content;
+  height: auto;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  overflow: visible;
+  clip-path: none;
+  white-space: normal;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  font-weight: 500;
+  box-shadow:
+    0 1px 3px 0 rgb(0 0 0 / 0.08),
+    0 1px 2px -1px rgb(0 0 0 / 0.08);
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
 }
 
 .wrapper {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
+import { SkipLink } from "@/components/skip-link";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -31,15 +32,20 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">
+      <body className="relative min-h-full flex flex-col">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
         >
+          <SkipLink />
           <Header />
-          <main className="flex-1 wrapper flex flex-col items-start justify-start gap-[60px]">
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 wrapper flex flex-col items-start justify-start gap-[60px] outline-none"
+          >
             {children}
           </main>
           <Footer />

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,17 @@
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
+import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
+
+export default function RootLoading() {
+  return (
+    <>
+      <HeroSkeleton size="default" showBottomRow />
+      <ProjectsSectionSkeleton
+        cardCount={3}
+        gridClassName="grid-cols-[repeat(auto-fill,minmax(240px,1fr))]"
+        showViewAll
+      />
+      <PostsSectionSkeleton rowCount={4} showViewAll />
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,8 @@ import { HomeHero } from "./_components/home-hero";
 import { HomePosts } from "./_components/home-posts";
 import { HomeProjects } from "./_components/home-projects";
 
+export const revalidate = 10;
+
 export default function Home() {
   return (
     <>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,59 +1,31 @@
-import { Typography } from "@/components/typography";
-import Hero from "@/sections/hero";
-import PostsSection from "@/sections/posts";
-import ProjectsSection from "@/sections/projects";
-import { getDatabasePages, getPageData } from "@/services/notion";
-import { formatPageMetadata, formatPostMetadata } from "@/utils/formatter";
-import { Fragment } from "react";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
+import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
+import { Suspense } from "react";
+import { HomeHero } from "./_components/home-hero";
+import { HomePosts } from "./_components/home-posts";
+import { HomeProjects } from "./_components/home-projects";
 
-export default async function Home() {
-  const page = await getPageData(process.env.NOTION_PAGE_HOME_ID!);
-  const pageMetadata = formatPageMetadata(page);
-
-  const blogPages = await getDatabasePages(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Blog",
-    4,
-  );
-
-  const projectPages = await getDatabasePages(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Project",
-    3,
-  );
-
-  const blogPostMetadata = formatPostMetadata(blogPages);
-  const projectPostMetadata = formatPostMetadata(projectPages);
-
+export default function Home() {
   return (
-    <Fragment>
-      <Hero
-        title={pageMetadata.title}
-        description={pageMetadata.description}
-        bottom={
-          <div className="w-full flex items-center justify-between gap-2">
-            <Typography className="font-bold text-muted-foreground line-clamp-1 break-all">
-              {pageMetadata.role}
-            </Typography>
-            <Typography className="font-bold text-muted-foreground line-clamp-1 break-all">
-              📍 {pageMetadata.location}
-            </Typography>
-          </div>
+    <>
+      <Suspense fallback={<HeroSkeleton size="default" showBottomRow />}>
+        <HomeHero />
+      </Suspense>
+      <Suspense
+        fallback={
+          <ProjectsSectionSkeleton
+            cardCount={3}
+            gridClassName="grid-cols-[repeat(auto-fill,minmax(240px,1fr))]"
+            showViewAll
+          />
         }
-      />
-      <ProjectsSection
-        title="Latest Projects"
-        href="/work"
-        id="work"
-        posts={projectPostMetadata}
-        className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(240px,1fr))] gap-5 justify-center"
-      />
-      <PostsSection
-        title="Latest Posts"
-        href="/blog"
-        id="blog"
-        posts={blogPostMetadata}
-      />
-    </Fragment>
+      >
+        <HomeProjects />
+      </Suspense>
+      <Suspense fallback={<PostsSectionSkeleton rowCount={4} showViewAll />}>
+        <HomePosts />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/work/[slug]/_components/work-post-body.tsx
+++ b/src/app/work/[slug]/_components/work-post-body.tsx
@@ -1,0 +1,22 @@
+import ContentSection from "@/sections/content";
+import { getDatabasePageBySlug, getPageBlocks } from "@/services/notion";
+import { formatBlockWithChildren } from "@/utils/formatter";
+import { notFound } from "next/navigation";
+
+export async function WorkPostBody({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const found = await getDatabasePageBySlug(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Project",
+    slug,
+  );
+  if (!found) notFound();
+
+  const pageBlocks = await getPageBlocks(found.page.id);
+  const pageContent = formatBlockWithChildren(pageBlocks);
+  return <ContentSection blocks={pageContent} />;
+}

--- a/src/app/work/[slug]/_components/work-post-hero.tsx
+++ b/src/app/work/[slug]/_components/work-post-hero.tsx
@@ -1,0 +1,39 @@
+import { HeadingTop } from "@/components/heading-top";
+import Hero from "@/sections/hero";
+import { getDatabasePageBySlug } from "@/services/notion";
+import { formatPostDateFull } from "@/utils/formatter";
+import { notFound } from "next/navigation";
+
+export async function WorkPostHero({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const found = await getDatabasePageBySlug(
+    process.env.NOTION_DATABASE_CONTENT_ID!,
+    "Project",
+    slug,
+  );
+  if (!found) notFound();
+
+  const { metadata } = found;
+  const dateLabel = formatPostDateFull(metadata.published_date);
+
+  return (
+    <Hero
+      top={
+        <HeadingTop
+          title={metadata.title}
+          date={dateLabel}
+          postsPath="/work"
+          postType="Projects"
+        />
+      }
+      title={metadata.title}
+      description={metadata.description}
+      thumbnail={metadata.thumbnail}
+      size="small"
+    />
+  );
+}

--- a/src/app/work/[slug]/_components/work-post-hero.tsx
+++ b/src/app/work/[slug]/_components/work-post-hero.tsx
@@ -26,6 +26,7 @@ export async function WorkPostHero({
         <HeadingTop
           title={metadata.title}
           date={dateLabel}
+          dateTime={metadata.published_date}
           postsPath="/work"
           postType="Projects"
         />

--- a/src/app/work/[slug]/loading.tsx
+++ b/src/app/work/[slug]/loading.tsx
@@ -1,0 +1,11 @@
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+
+export default function WorkPostLoading() {
+  return (
+    <>
+      <HeroSkeleton showThumbnail showTopNav size="small" />
+      <ContentSectionSkeleton />
+    </>
+  );
+}

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,19 +1,11 @@
-import { HeadingTop } from "@/components/heading-top";
-import ContentSection from "@/sections/content";
-import Hero from "@/sections/hero";
-import {
-  getDatabasePageBySlug,
-  getDatabasePages,
-  getPageBlocks,
-} from "@/services/notion";
-import {
-  formatBlockWithChildren,
-  formatPostDateFull,
-  formatPostMetadata,
-} from "@/utils/formatter";
-import { Metadata } from "next";
-import { notFound } from "next/navigation";
-import { Fragment } from "react";
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { getDatabasePages, getDatabasePageBySlug } from "@/services/notion";
+import { formatPostMetadata } from "@/utils/formatter";
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { WorkPostBody } from "./_components/work-post-body";
+import { WorkPostHero } from "./_components/work-post-hero";
 
 const SLUG_PAGE_LIMIT = 100;
 
@@ -43,42 +35,19 @@ export async function generateMetadata({
   };
 }
 
-export default async function WorkPostPage({
+export default function WorkPostPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  const { slug } = await params;
-  const found = await getDatabasePageBySlug(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Project",
-    slug,
-  );
-  if (!found) notFound();
-
-  const { metadata } = found;
-  const pageBlocks = await getPageBlocks(found.page.id);
-  const pageContent = formatBlockWithChildren(pageBlocks);
-
-  const dateLabel = formatPostDateFull(metadata.published_date);
-
   return (
-    <Fragment>
-      <Hero
-        top={
-          <HeadingTop
-            title={metadata.title}
-            date={dateLabel}
-            postsPath="/work"
-            postType="Projects"
-          />
-        }
-        title={metadata.title}
-        description={metadata.description}
-        thumbnail={metadata.thumbnail}
-        size="small"
-      />
-      <ContentSection blocks={pageContent} />
-    </Fragment>
+    <>
+      <Suspense fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}>
+        <WorkPostHero params={params} />
+      </Suspense>
+      <Suspense fallback={<ContentSectionSkeleton />}>
+        <WorkPostBody params={params} />
+      </Suspense>
+    </>
   );
 }

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { Suspense } from "react";
 import { WorkPostBody } from "./_components/work-post-body";
 import { WorkPostHero } from "./_components/work-post-hero";
 
+export const revalidate = 10;
+
 const SLUG_PAGE_LIMIT = 100;
 
 export async function generateStaticParams() {

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
-import { getDatabasePages, getDatabasePageBySlug } from "@/services/notion";
-import { formatPostMetadata } from "@/utils/formatter";
+import {
+  getAllPublishedSlugsForStaticParams,
+  getDatabasePageBySlug,
+} from "@/services/notion";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { WorkPostBody } from "./_components/work-post-body";
@@ -9,12 +11,9 @@ import { WorkPostHero } from "./_components/work-post-hero";
 
 export const revalidate = 10;
 
-const SLUG_PAGE_LIMIT = 100;
-
 export async function generateStaticParams() {
   const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
-  const pages = await getDatabasePages(databaseId, "Project", SLUG_PAGE_LIMIT);
-  return formatPostMetadata(pages).map((p) => ({ slug: p.slug }));
+  return getAllPublishedSlugsForStaticParams(databaseId, "Project");
 }
 
 export async function generateMetadata({

--- a/src/app/work/loading.tsx
+++ b/src/app/work/loading.tsx
@@ -1,0 +1,16 @@
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
+
+export default function WorkLoading() {
+  return (
+    <>
+      <HeroSkeleton size="small" />
+      <ProjectsSectionSkeleton
+        cardCount={6}
+        gridClassName="grid-cols-[repeat(auto-fill,minmax(300px,1fr))]"
+      />
+      <ContentSectionSkeleton />
+    </>
+  );
+}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -6,6 +6,8 @@ import { WorkBody } from "../_components/work-body";
 import { WorkHero } from "../_components/work-hero";
 import { WorkProjects } from "../_components/work-projects";
 
+export const revalidate = 10;
+
 export default function WorkPage() {
   return (
     <>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,45 +1,30 @@
-import ContentSection from "@/sections/content";
-import Hero from "@/sections/hero";
-import ProjectsSection from "@/sections/projects";
-import {
-  getDatabasePages,
-  getPageBlocks,
-  getPageData,
-} from "@/services/notion";
-import {
-  formatBlockWithChildren,
-  formatPageMetadata,
-  formatPostMetadata,
-} from "@/utils/formatter";
-import { Fragment } from "react";
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
+import { Suspense } from "react";
+import { WorkBody } from "../_components/work-body";
+import { WorkHero } from "../_components/work-hero";
+import { WorkProjects } from "../_components/work-projects";
 
-export default async function WorkPage() {
-  const page = await getPageData(process.env.NOTION_PAGE_WORK_ID!);
-  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_WORK_ID!);
-  const projectPages = await getDatabasePages(
-    process.env.NOTION_DATABASE_CONTENT_ID!,
-    "Project",
-    20,
-  );
-
-  const pageContent = formatBlockWithChildren(pageBlocks);
-  const pageMetadata = formatPageMetadata(page);
-  const projectPostMetadata = formatPostMetadata(projectPages);
-
+export default function WorkPage() {
   return (
-    <Fragment>
-      <Hero
-        title={pageMetadata.title}
-        description={pageMetadata.description}
-        size="small"
-      />
-      <ProjectsSection
-        title="Latest Projects"
-        id="work"
-        posts={projectPostMetadata}
-        className="grid auto-rows-fr grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-5 justify-center"
-      />
-      <ContentSection blocks={pageContent} />
-    </Fragment>
+    <>
+      <Suspense fallback={<HeroSkeleton size="small" />}>
+        <WorkHero />
+      </Suspense>
+      <Suspense
+        fallback={
+          <ProjectsSectionSkeleton
+            cardCount={6}
+            gridClassName="grid-cols-[repeat(auto-fill,minmax(300px,1fr))]"
+          />
+        }
+      >
+        <WorkProjects />
+      </Suspense>
+      <Suspense fallback={<ContentSectionSkeleton />}>
+        <WorkBody />
+      </Suspense>
+    </>
   );
 }

--- a/src/components/content-blocks.tsx
+++ b/src/components/content-blocks.tsx
@@ -39,7 +39,15 @@ export const ImageBlock = withContentValidation((props: DropedProps) => {
 export const VideoBlock = withContentValidation((props: DropedProps) => {
   const embedUrl = props.media?.src?.replace("watch?v=", "embed/");
 
-  return <iframe src={embedUrl} className="w-full aspect-video" />;
+  return (
+    <iframe
+      src={embedUrl}
+      title="Embedded video"
+      className="aspect-video w-full"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowFullScreen
+    />
+  );
 });
 
 export const Heading1Block = withContentValidation((props: DropedProps) => {

--- a/src/components/content-blocks.tsx
+++ b/src/components/content-blocks.tsx
@@ -103,6 +103,7 @@ function mapParagraphChildren(children: React.ReactNode): React.ReactNode[] {
             className="underline underline-offset-2 hover:text-accent-foreground transition-all duration-300"
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={text}
           >
             {text}
           </a>

--- a/src/components/cover-image.tsx
+++ b/src/components/cover-image.tsx
@@ -6,17 +6,27 @@ interface CoverImageProps {
   src: string;
   alt: string;
   className?: string;
+  /** Responsive hint for the image optimizer (matches `.wrapper` max width). */
+  sizes?: string;
+  priority?: boolean;
 }
 
-export function CoverImage({ src, alt, className }: CoverImageProps) {
+export function CoverImage({
+  src,
+  alt,
+  className,
+  sizes = "(max-width: 768px) 100vw, 840px",
+  priority = false,
+}: CoverImageProps) {
   return (
     <Image
       src={src}
       alt={alt}
       width={1000}
       height={1000}
+      sizes={sizes}
+      priority={priority}
       className={cn("thumbnail", className)}
-      loading="eager"
       placeholder="blur"
       blurDataURL={assets.base64}
     />

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -15,7 +15,9 @@ export const Footer = () => {
           © Nubelson Fernandes | {currentYear}
         </Typography>
 
-        <NavigationList items={footerNavigation} className="font-normal" />
+        <nav aria-label="Footer navigation">
+          <NavigationList items={footerNavigation} className="font-normal" />
+        </nav>
       </div>
     </footer>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,11 +1,10 @@
 import navigation from "@/data/navigation.json";
 import social from "@/data/social.json";
 import { RiGithubLine, RiMailOpenLine, RiYoutubeLine } from "@remixicon/react";
-import { Sun } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
 import { NavigationList } from "./navigation-list";
-import { Button } from "./ui/button";
+import { ThemeToggle } from "./theme-toggle";
 import { Separator } from "./ui/separator";
 
 export const Header = () => {
@@ -67,15 +66,7 @@ export const Header = () => {
           orientation="vertical"
           className="h-5 data-vertical:self-center hidden lg:block"
         />
-        <Button
-          disabled
-          aria-label="Theme toggle (coming soon)"
-          variant="ghost"
-          size="icon"
-          className="hidden lg:block"
-        >
-          <Sun />
-        </Button>
+        <ThemeToggle />
       </div>
     </header>
   );

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -41,7 +41,12 @@ export const Header = () => {
             const iconSize = 16;
 
             return (
-              <a key={item.label} href={item.url} target="_blank">
+              <a
+                key={item.label}
+                aria-label={item.label}
+                href={item.url}
+                target="_blank"
+              >
                 {item.icon === "RiYoutubeLine" && (
                   <RiYoutubeLine size={iconSize} className={iconStyle} />
                 )}
@@ -62,6 +67,7 @@ export const Header = () => {
         />
         <Button
           disabled
+          aria-label="Toggle theme"
           variant="ghost"
           size="icon"
           className="hidden lg:block"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,6 +22,7 @@ export const Header = () => {
             width={32}
             height={32}
             className="dark:invert"
+            loading="eager"
           />
         </Link>
         <Separator

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -13,12 +13,12 @@ export const Header = () => {
   const socialMedia = social.media;
 
   return (
-    <header className="wrapper py-3 flex items-center justify-between">
+    <header className="wrapper flex items-center justify-between py-3">
       <div className="flex items-center justify-start gap-5">
-        <Link href="/">
+        <Link href="/" aria-label="Go to homepage">
           <Image
             src="/logo.svg"
-            alt="Logo"
+            alt=""
             width={32}
             height={32}
             className="dark:invert"
@@ -29,7 +29,7 @@ export const Header = () => {
           orientation="vertical"
           className="h-5 data-vertical:self-center"
         />
-        <nav>
+        <nav aria-label="Main navigation">
           <NavigationList items={headerNavigation} />
         </nav>
       </div>
@@ -47,6 +47,7 @@ export const Header = () => {
                 aria-label={item.label}
                 href={item.url}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 {item.icon === "RiYoutubeLine" && (
                   <RiYoutubeLine size={iconSize} className={iconStyle} />
@@ -68,7 +69,7 @@ export const Header = () => {
         />
         <Button
           disabled
-          aria-label="Toggle theme"
+          aria-label="Theme toggle (coming soon)"
           variant="ghost"
           size="icon"
           className="hidden lg:block"

--- a/src/components/heading-top.tsx
+++ b/src/components/heading-top.tsx
@@ -22,7 +22,9 @@ export function HeadingTop({
           size="small"
           className="text-muted-foreground hover:text-accent-foreground transition-colors duration-300"
         >
-          <Link href={postsPath}>All {postType}</Link>
+          <Link href={postsPath} aria-label={`View all ${postType}`}>
+            All {postType}
+          </Link>
         </Typography>
 
         <Separator
@@ -38,7 +40,8 @@ export function HeadingTop({
       </div>
 
       <Typography size="small" className="text-muted-foreground">
-        🗓️ {date}
+        <span aria-hidden>🗓️ </span>
+        {date}
       </Typography>
     </div>
   );

--- a/src/components/heading-top.tsx
+++ b/src/components/heading-top.tsx
@@ -5,6 +5,8 @@ import { Separator } from "./ui/separator";
 interface HeadingTopProps {
   title: string;
   date: string;
+  /** Raw ISO/machine date for `<time>` (e.g. Notion publish date string). */
+  dateTime: string;
   postsPath: string;
   postType?: string;
 }
@@ -12,6 +14,7 @@ interface HeadingTopProps {
 export function HeadingTop({
   title,
   date,
+  dateTime,
   postsPath,
   postType = "Posts",
 }: HeadingTopProps) {
@@ -41,7 +44,7 @@ export function HeadingTop({
 
       <Typography size="small" className="text-muted-foreground">
         <span aria-hidden>🗓️ </span>
-        {date}
+        <time dateTime={dateTime}>{date}</time>
       </Typography>
     </div>
   );

--- a/src/components/navigation-list.tsx
+++ b/src/components/navigation-list.tsx
@@ -31,7 +31,12 @@ export const NavigationList = ({ items, className }: NavigationListProps) => {
             className,
           )}
         >
-          <Link href={item.path}>{item.label}</Link>
+          <Link
+            href={item.path}
+            aria-current={pathname === item.path ? "page" : undefined}
+          >
+            {item.label}
+          </Link>
         </Typography>
       ))}
     </ul>

--- a/src/components/post-item.tsx
+++ b/src/components/post-item.tsx
@@ -1,4 +1,4 @@
-import { Typography } from "@/components/typography";
+import { Typography, typographyVariants } from "@/components/typography";
 import { Item, ItemContent, ItemTitle } from "@/components/ui/item";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
@@ -16,13 +16,16 @@ export function PostItem({ separator = true, post }: PostItemProps) {
       <ItemContent className="gap-2.5">
         <ItemTitle className="font-normal w-full flex items-center justify-between gap-2">
           <div className="flex items-center justify-start gap-2 md:max-w-[95%]">
-            <Typography
-              component="span"
-              size="small"
-              className="text-muted-foreground w-20 line-clamp-1 break-all"
+            <time
+              dateTime={post.published_date}
+              className={typographyVariants({
+                size: "small",
+                className:
+                  "text-muted-foreground w-20 line-clamp-1 break-all",
+              })}
             >
               {formatPostDate(post.published_date)}
-            </Typography>
+            </time>
             <Typography
               component="h3"
               className="flex-1 text-accent-foreground line-clamp-1 break-all"

--- a/src/components/project-item.tsx
+++ b/src/components/project-item.tsx
@@ -36,7 +36,7 @@ export function ProjectItem({ post }: ProjectItemProps) {
         </ItemTitle>
         <Typography
           size="small"
-          className="text-muted-foreground line-clamp-2 break-all"
+          className="text-muted-foreground group-hover/item:text-accent-foreground transition-colors duration-300 line-clamp-2 break-all"
         >
           {post.description}
         </Typography>

--- a/src/components/project-item.tsx
+++ b/src/components/project-item.tsx
@@ -18,8 +18,9 @@ export function ProjectItem({ post }: ProjectItemProps) {
             alt={post.title}
             width={640}
             height={424}
-            loading="eager"
-            className="w-full h-full object-cover aspect-4/3"
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 360px"
+            loading="lazy"
+            className="aspect-4/3 h-full w-full object-cover"
           />
         )}
       </ItemMedia>

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -5,13 +5,15 @@ import { Separator } from "./ui/separator";
 interface SectionHeaderProps {
   title: string;
   href?: string;
+  /** When set, labels this region for assistive tech (pairs with `section` `aria-labelledby`). */
+  titleId?: string;
 }
 
-export function SectionHeader({ title, href }: SectionHeaderProps) {
+export function SectionHeader({ title, href, titleId }: SectionHeaderProps) {
   return (
     <div className="w-full flex flex-col items-start justify-start gap-2">
       <div className="w-full flex items-center justify-between">
-        <Typography component="h2" variant="h3">
+        <Typography component="h2" variant="h3" id={titleId}>
           {title}
         </Typography>
         {href && (
@@ -19,7 +21,7 @@ export function SectionHeader({ title, href }: SectionHeaderProps) {
             size="small"
             className="text-muted-foreground hover:text-accent-foreground transition-colors duration-300 underline-offset-4 hover:underline"
           >
-            <Link aria-label="View all" href={href}>
+            <Link aria-label={`View all ${title}`} href={href}>
               View all
             </Link>
           </Typography>

--- a/src/components/section-header.tsx
+++ b/src/components/section-header.tsx
@@ -19,7 +19,9 @@ export function SectionHeader({ title, href }: SectionHeaderProps) {
             size="small"
             className="text-muted-foreground hover:text-accent-foreground transition-colors duration-300 underline-offset-4 hover:underline"
           >
-            <Link href={href}>View all</Link>
+            <Link aria-label="View all" href={href}>
+              View all
+            </Link>
           </Typography>
         )}
       </div>

--- a/src/components/section-wrapper.tsx
+++ b/src/components/section-wrapper.tsx
@@ -1,6 +1,7 @@
+import { cn } from "@/lib/utils";
 import { SectionHeader } from "./section-header";
 
-interface SectionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
+interface SectionWrapperProps extends React.HTMLAttributes<HTMLElement> {
   title: string;
   path?: string;
   children: React.ReactNode;
@@ -10,14 +11,23 @@ export function SectionWrapper({
   title,
   path,
   children,
+  id,
+  className,
   ...props
 }: SectionWrapperProps) {
+  const headingId = typeof id === "string" ? `${id}-heading` : undefined;
+
   return (
     <section
       {...props}
-      className="w-full flex flex-col items-center justify-start gap-8 pb-5"
+      id={id}
+      aria-labelledby={headingId}
+      className={cn(
+        "flex w-full flex-col items-center justify-start gap-8 pb-5",
+        className,
+      )}
     >
-      <SectionHeader title={title} href={path} />
+      <SectionHeader title={title} href={path} titleId={headingId} />
 
       {children}
     </section>

--- a/src/components/skeletons/content-section-skeleton.tsx
+++ b/src/components/skeletons/content-section-skeleton.tsx
@@ -1,0 +1,35 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface ContentSectionSkeletonProps {
+  blocks?: number;
+}
+
+export function ContentSectionSkeleton({ blocks = 8 }: ContentSectionSkeletonProps) {
+  return (
+    <section
+      aria-hidden
+      className="flex w-full flex-col items-start justify-start space-y-5"
+      id="content"
+    >
+      {Array.from({ length: blocks }).map((_, i) => (
+        <BlockLineSkeleton key={i} variant={i % 4} />
+      ))}
+    </section>
+  );
+}
+
+function BlockLineSkeleton({ variant }: { variant: number }) {
+  if (variant === 0) {
+    return <Skeleton className="h-8 w-[min(100%,340px)] rounded-lg" />;
+  }
+  if (variant === 1) {
+    return (
+      <div className="flex w-full flex-col gap-2">
+        <Skeleton className="h-5 w-full max-w-none rounded-md" />
+        <Skeleton className="h-5 w-full max-w-2xl rounded-md" />
+        <Skeleton className="h-5 w-[72%] max-w-xl rounded-md" />
+      </div>
+    );
+  }
+  return <Skeleton className="h-4 w-[min(100%,280px)] rounded-md" />;
+}

--- a/src/components/skeletons/hero-skeleton.tsx
+++ b/src/components/skeletons/hero-skeleton.tsx
@@ -17,11 +17,11 @@ export function HeroSkeleton({
     size === "small" ? "h-8 w-[min(100%,420px)]" : "h-11 w-[min(100%,520px)]";
 
   return (
-    <section className="flex flex-col items-start justify-start gap-[60px] pt-31 pb-5">
+    <section className="w-full flex flex-col items-start justify-start gap-[60px] pt-31 pb-5">
       <div className="flex w-full flex-col items-start justify-start gap-5">
         {showTopNav && (
-          <div className="flex w-full flex-wrap items-center gap-4">
-            <Skeleton className="h-9 w-[min(80%,380px)]" />
+          <div className="flex w-full flex-wrap items-center justify-between gap-4">
+            <Skeleton className="h-4 w-[min(80%,380px)]" />
             <Skeleton className="h-4 w-28" />
           </div>
         )}
@@ -34,8 +34,8 @@ export function HeroSkeleton({
             </div>
           )}
         </div>
-        <Skeleton className="h-5 max-w-xl w-full rounded-md" />
-        <Skeleton className="h-5 max-w-[85%] rounded-md md:max-w-md" />
+        <Skeleton className="h-5 w-full rounded-md" />
+        <Skeleton className="h-5 w-full rounded-md md:max-w-md" />
       </div>
       {showThumbnail && (
         <Skeleton className="aspect-4/3 w-full max-w-4xl rounded-lg" />

--- a/src/components/skeletons/hero-skeleton.tsx
+++ b/src/components/skeletons/hero-skeleton.tsx
@@ -1,0 +1,45 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface HeroSkeletonProps {
+  size?: "default" | "small";
+  showThumbnail?: boolean;
+  showBottomRow?: boolean;
+  showTopNav?: boolean;
+}
+
+export function HeroSkeleton({
+  size = "default",
+  showThumbnail = false,
+  showBottomRow = false,
+  showTopNav = false,
+}: HeroSkeletonProps) {
+  const titleHeight =
+    size === "small" ? "h-8 w-[min(100%,420px)]" : "h-11 w-[min(100%,520px)]";
+
+  return (
+    <section className="flex flex-col items-start justify-start gap-[60px] pt-31 pb-5">
+      <div className="flex w-full flex-col items-start justify-start gap-5">
+        {showTopNav && (
+          <div className="flex w-full flex-wrap items-center gap-4">
+            <Skeleton className="h-9 w-[min(80%,380px)]" />
+            <Skeleton className="h-4 w-28" />
+          </div>
+        )}
+        <div className="flex w-full flex-col items-start gap-1.5">
+          <Skeleton className={`rounded-lg ${titleHeight}`} />
+          {showBottomRow && (
+            <div className="mt-2 flex w-full items-center justify-between gap-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-36" />
+            </div>
+          )}
+        </div>
+        <Skeleton className="h-5 max-w-xl w-full rounded-md" />
+        <Skeleton className="h-5 max-w-[85%] rounded-md md:max-w-md" />
+      </div>
+      {showThumbnail && (
+        <Skeleton className="aspect-4/3 w-full max-w-4xl rounded-lg" />
+      )}
+    </section>
+  );
+}

--- a/src/components/skeletons/page-skeleton.tsx
+++ b/src/components/skeletons/page-skeleton.tsx
@@ -1,0 +1,20 @@
+import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
+import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
+
+interface PageSkeletonProps {
+  heroSize?: "default" | "small";
+  contentBlocks?: number;
+}
+
+/** Full-page stub for route `loading.tsx` (navigation transitions). */
+export function PageSkeleton({
+  heroSize = "small",
+  contentBlocks = 6,
+}: PageSkeletonProps) {
+  return (
+    <>
+      <HeroSkeleton size={heroSize} showThumbnail />
+      <ContentSectionSkeleton blocks={contentBlocks} />
+    </>
+  );
+}

--- a/src/components/skeletons/posts-section-skeleton.tsx
+++ b/src/components/skeletons/posts-section-skeleton.tsx
@@ -1,0 +1,39 @@
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PostsSectionSkeletonProps {
+  rowCount?: number;
+  showViewAll?: boolean;
+}
+
+export function PostsSectionSkeleton({
+  rowCount = 4,
+  showViewAll = false,
+}: PostsSectionSkeletonProps) {
+  return (
+    <section className="flex w-full flex-col items-center justify-start gap-8 pb-5">
+      <div className="flex w-full flex-col items-start justify-start gap-2">
+        <div className="flex w-full items-center justify-between">
+          <Skeleton className="h-8 w-36 rounded-lg" />
+          {showViewAll && <Skeleton className="h-4 w-16 rounded-md" />}
+        </div>
+        <Separator />
+      </div>
+
+      <div className="flex w-full flex-col items-start justify-start gap-3">
+        {Array.from({ length: rowCount }).map((_, i) => (
+          <div key={i} className="flex w-full flex-col gap-2.5">
+            <div className="flex w-full items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <Skeleton className="h-4 w-20 shrink-0 rounded-md" />
+                <Skeleton className="h-5 min-w-0 flex-1 rounded-md" />
+              </div>
+              <Skeleton className="hidden h-4 w-4 shrink-0 rounded md:block" />
+            </div>
+            {i < rowCount - 1 && <Separator />}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/skeletons/projects-section-skeleton.tsx
+++ b/src/components/skeletons/projects-section-skeleton.tsx
@@ -1,0 +1,50 @@
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface ProjectsSectionSkeletonProps {
+  cardCount?: number;
+  gridClassName: string;
+  showViewAll?: boolean;
+}
+
+export function ProjectsSectionSkeleton({
+  cardCount = 3,
+  gridClassName,
+  showViewAll = false,
+}: ProjectsSectionSkeletonProps) {
+  return (
+    <section className="flex w-full flex-col items-center justify-start gap-8 pb-5">
+      <div className="flex w-full flex-col items-start justify-start gap-2">
+        <div className="flex w-full items-center justify-between">
+          <Skeleton className="h-8 w-40 rounded-lg" />
+          {showViewAll && <Skeleton className="h-4 w-16 rounded-md" />}
+        </div>
+        <Separator />
+      </div>
+
+      <div
+        className={cn(
+          "grid w-full auto-rows-fr justify-center gap-5",
+          gridClassName,
+        )}
+      >
+        {Array.from({ length: cardCount }).map((_, i) => (
+          <ProjectCardSkeleton key={i} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ProjectCardSkeleton() {
+  return (
+    <div className="flex w-full flex-col items-start gap-2.5">
+      <Skeleton className="aspect-4/3 w-full rounded-lg" />
+      <div className="flex w-full flex-col gap-2">
+        <Skeleton className="h-5 w-4/5 rounded-md" />
+        <Skeleton className="h-4 w-full max-w-[240px] rounded-md" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/skip-link.tsx
+++ b/src/components/skip-link.tsx
@@ -1,0 +1,13 @@
+/**
+ * First focusable control: moves keyboard users past the header into `#main-content`.
+ */
+export function SkipLink() {
+  return (
+    <a
+      href="#main-content"
+      className="skip-link"
+    >
+      Skip to main content
+    </a>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import { cn } from "@/lib/utils";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      setMounted(true);
+    });
+  }, []);
+
+  if (!mounted) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon"
+        className="hidden lg:block"
+        disabled
+        aria-hidden
+      >
+        <Sun />
+      </Button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+  const icon =
+    "absolute left-1/2 top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 transition-all";
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="relative hidden lg:block cursor-pointer"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      <Sun
+        className={cn(
+          icon,
+          isDark
+            ? "-rotate-90 scale-0 opacity-0"
+            : "rotate-0 scale-100 opacity-100",
+        )}
+        aria-hidden
+      />
+      <Moon
+        className={cn(
+          icon,
+          isDark
+            ? "rotate-0 scale-100 opacity-100"
+            : "rotate-90 scale-0 opacity-0",
+        )}
+        aria-hidden
+      />
+    </Button>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react";
+
+function Skeleton({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/src/lib/map-pool.ts
+++ b/src/lib/map-pool.ts
@@ -1,0 +1,25 @@
+/**
+ * Maps items with at most `limit` concurrent async operations.
+ * Helps avoid Notion API rate spikes when many blocks have children.
+ */
+export async function mapPool<T, R>(
+  items: readonly T[],
+  limit: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array(items.length);
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) break;
+      results[i] = await mapper(items[i]!);
+    }
+  }
+
+  const workers = Math.min(Math.max(1, limit), items.length);
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return results;
+}

--- a/src/sections/hero.tsx
+++ b/src/sections/hero.tsx
@@ -26,7 +26,7 @@ export default function HeroSection({
         <Typography className="text-muted-foreground">{description}</Typography>
       )}
 
-      {thumbnail && <CoverImage src={thumbnail} alt={title} />}
+      {thumbnail && <CoverImage src={thumbnail} alt={title} priority />}
     </section>
   );
 }

--- a/src/sections/posts.tsx
+++ b/src/sections/posts.tsx
@@ -20,7 +20,12 @@ export default function PostsSection({
     <SectionWrapper title={title} path={href} id={id}>
       <div className="w-full flex flex-col items-start justify-start gap-3">
         {posts.map((post, index) => (
-          <Link href={`/blog/${post.slug}`} key={post.id} className="w-full">
+          <Link
+            href={`/blog/${post.slug}`}
+            key={post.id}
+            className="w-full"
+            aria-label={`${post.title} — read post`}
+          >
             <PostItem post={post} separator={index !== posts.length - 1} />
           </Link>
         ))}

--- a/src/sections/projects.tsx
+++ b/src/sections/projects.tsx
@@ -23,7 +23,12 @@ export default function ProjectsSection({
     <SectionWrapper title={title} path={href} id={id}>
       <div className={cn("w-full", className)}>
         {posts.map((post) => (
-          <Link className="h-min" href={`/work/${post.slug}`} key={post.id}>
+          <Link
+            className="h-min"
+            href={`/work/${post.slug}`}
+            key={post.id}
+            aria-label={`${post.title} — view project`}
+          >
             <ProjectItem post={post} />
           </Link>
         ))}

--- a/src/services/notion.tsx
+++ b/src/services/notion.tsx
@@ -7,6 +7,7 @@ import {
   isFullPage,
   type PageObjectResponse,
 } from "@notionhq/client";
+import { unstable_cache } from "next/cache";
 import { cache } from "react";
 
 const api = new Client({
@@ -15,6 +16,9 @@ const api = new Client({
 
 /** Max concurrent child-block fetches per level (Notion rate limits). */
 const PAGE_BLOCKS_FETCH_CONCURRENCY = 10;
+
+/** Max nesting depth when resolving block children (avoids huge trees). */
+const MAX_BLOCK_DEPTH = 5;
 
 const QUERY_PAGE_SIZE = 100;
 
@@ -195,38 +199,48 @@ export type BlockWithChildren = BlockObjectResponse & {
   children?: BlockWithChildren[];
 };
 
-export const getPageBlocks = cache(
-  async (pageId: string): Promise<BlockWithChildren[]> => {
-    const blocks: BlockObjectResponse[] = [];
-    let cursor: string | undefined = undefined;
+async function fetchBlocksRecursive(
+  pageId: string,
+  depth: number,
+): Promise<BlockWithChildren[]> {
+  const blocks: BlockObjectResponse[] = [];
+  let cursor: string | undefined = undefined;
 
-    do {
-      const response = await api.blocks.children.list({
-        block_id: pageId,
-        start_cursor: cursor,
-        page_size: 100,
-      });
+  do {
+    const response = await api.blocks.children.list({
+      block_id: pageId,
+      start_cursor: cursor,
+      page_size: 100,
+    });
 
-      blocks.push(...response.results.filter(isFullBlock));
+    blocks.push(...response.results.filter(isFullBlock));
 
-      cursor = response.has_more
-        ? (response.next_cursor ?? undefined)
-        : undefined;
-    } while (cursor);
+    cursor = response.has_more
+      ? (response.next_cursor ?? undefined)
+      : undefined;
+  } while (cursor);
 
-    const blocksWithChildren = await mapPool(
-      blocks,
-      PAGE_BLOCKS_FETCH_CONCURRENCY,
-      async (block) => {
-        if (!block.has_children) return block;
+  const blocksWithChildren = await mapPool(
+    blocks,
+    PAGE_BLOCKS_FETCH_CONCURRENCY,
+    async (block) => {
+      if (!block.has_children || depth <= 0) return block;
 
-        return {
-          ...block,
-          children: await getPageBlocks(block.id),
-        };
-      },
-    );
+      return {
+        ...block,
+        children: await fetchBlocksRecursive(block.id, depth - 1),
+      };
+    },
+  );
 
-    return formatBlockWithChildren(blocksWithChildren);
-  },
+  return formatBlockWithChildren(blocksWithChildren);
+}
+
+const fetchPageBlocksCached = unstable_cache(
+  async (pageId: string) =>
+    fetchBlocksRecursive(pageId, MAX_BLOCK_DEPTH),
+  ["notion-page-blocks"],
+  { tags: ["notion-blocks"], revalidate: 3600 },
 );
+
+export const getPageBlocks = cache(fetchPageBlocksCached);

--- a/src/services/notion.tsx
+++ b/src/services/notion.tsx
@@ -1,15 +1,85 @@
+import { mapPool } from "@/lib/map-pool";
 import { formatBlockWithChildren, formatPostMetadata } from "@/utils/formatter";
 import {
   BlockObjectResponse,
   Client,
   isFullBlock,
   isFullPage,
+  type PageObjectResponse,
 } from "@notionhq/client";
 import { cache } from "react";
 
 const api = new Client({
   auth: process.env.NOTION_ACCESS_TOKEN,
 });
+
+/** Max concurrent child-block fetches per level (Notion rate limits). */
+const PAGE_BLOCKS_FETCH_CONCURRENCY = 10;
+
+const QUERY_PAGE_SIZE = 100;
+
+const mediaMap = {
+  Blog: "Blog",
+  Project: "Project",
+} as const;
+
+const publishedBaseFilters = (media: string) =>
+  [
+    {
+      property: "Media",
+      select: {
+        equals: media,
+      },
+    },
+    {
+      property: "State",
+      select: {
+        equals: "Done",
+      },
+    },
+  ] as const;
+
+async function queryPublishedPagesPage(
+  databaseId: string,
+  media: string,
+  options: {
+    pageSize: number;
+    start_cursor?: string;
+    /** Narrow results (e.g. optional Notion `Slug` rich_text property). */
+    extraAnd?: unknown[];
+  },
+): Promise<{
+  pages: PageObjectResponse[];
+  next_cursor: string | undefined;
+}> {
+  const andFilters = [
+    ...publishedBaseFilters(media),
+    ...(options.extraAnd ?? []),
+  ];
+
+  const response = await api.dataSources.query({
+    data_source_id: databaseId,
+    filter: {
+      and: andFilters as never,
+    },
+    filter_properties: ["title", "Description", "Publish Date"],
+    sorts: [
+      {
+        property: "Publish Date",
+        direction: "descending",
+      },
+    ],
+    page_size: options.pageSize,
+    start_cursor: options.start_cursor,
+  });
+
+  return {
+    pages: response.results.filter(isFullPage),
+    next_cursor: response.has_more
+      ? (response.next_cursor ?? undefined)
+      : undefined,
+  };
+}
 
 export const getPageData = cache(async (pageId: string) => {
   const response = await api.pages.retrieve({ page_id: pageId });
@@ -26,53 +96,40 @@ const fetchDatabasePages = async (
   media: string,
   limit?: number,
 ) => {
-  const filters = [
-    {
-      property: "Media",
-      select: {
-        equals: media,
-      },
-    },
-    {
-      property: "State",
-      select: {
-        equals: "Done",
-      },
-    },
-  ];
-
-  try {
-    const response = await api.dataSources.query({
-      data_source_id: databaseId,
-      filter: {
-        and: filters,
-      },
-      filter_properties: ["title", "Description", "Publish Date"],
-      sorts: [
-        {
-          property: "Publish Date",
-          direction: "descending",
-        },
-      ],
-      page_size: limit,
-    });
-
-    return response.results.filter(isFullPage);
-  } catch (error) {
-    throw error;
-  }
+  const pageSize = Math.min(limit ?? QUERY_PAGE_SIZE, QUERY_PAGE_SIZE);
+  const { pages } = await queryPublishedPagesPage(databaseId, media, {
+    pageSize,
+  });
+  return pages;
 };
-
-const mediaMap = {
-  Blog: "Blog",
-  Project: "Project",
-} as const;
 
 export const getDatabasePages = cache(
   async (databaseId: string, media: keyof typeof mediaMap, limit?: number) => {
     return fetchDatabasePages(databaseId, mediaMap[media], limit);
   },
 );
+
+/**
+ * All published rows for static params (paginates past the first 100).
+ * @see getDatabasePageBySlug — same pagination for runtime slug resolution.
+ */
+export async function getAllPublishedSlugsForStaticParams(
+  databaseId: string,
+  media: keyof typeof mediaMap,
+): Promise<{ slug: string }[]> {
+  const out: { slug: string }[] = [];
+  let cursor: string | undefined;
+  do {
+    const { pages, next_cursor } = await queryPublishedPagesPage(
+      databaseId,
+      mediaMap[media],
+      { pageSize: QUERY_PAGE_SIZE, start_cursor: cursor },
+    );
+    out.push(...formatPostMetadata(pages).map((p) => ({ slug: p.slug })));
+    cursor = next_cursor;
+  } while (cursor);
+  return out;
+}
 
 /** Resolves a published database row by URL slug (derived from the page title). */
 export const getDatabasePageBySlug = cache(
@@ -81,14 +138,56 @@ export const getDatabasePageBySlug = cache(
     media: keyof typeof mediaMap,
     slug: string,
   ) => {
-    const pages = await getDatabasePages(databaseId, media, 100);
-    const metadataList = formatPostMetadata(pages);
-    const index = metadataList.findIndex((m) => m.slug === slug);
-    if (index === -1) return null;
-    return {
-      page: pages[index]!,
-      metadata: metadataList[index]!,
-    };
+    const slugProperty = process.env.NOTION_SLUG_PROPERTY?.trim();
+    if (slugProperty) {
+      try {
+        const { pages } = await queryPublishedPagesPage(
+          databaseId,
+          mediaMap[media],
+          {
+            pageSize: 10,
+            extraAnd: [
+              {
+                property: slugProperty,
+                rich_text: { equals: slug },
+              },
+            ],
+          },
+        );
+        if (pages.length > 0) {
+          const metadataList = formatPostMetadata(pages);
+          const index = metadataList.findIndex((m) => m.slug === slug);
+          if (index !== -1) {
+            return {
+              page: pages[index]!,
+              metadata: metadataList[index]!,
+            };
+          }
+        }
+      } catch {
+        /* wrong property name or type — fall back to scan */
+      }
+    }
+
+    let cursor: string | undefined;
+    do {
+      const { pages, next_cursor } = await queryPublishedPagesPage(
+        databaseId,
+        mediaMap[media],
+        { pageSize: QUERY_PAGE_SIZE, start_cursor: cursor },
+      );
+      const metadataList = formatPostMetadata(pages);
+      const index = metadataList.findIndex((m) => m.slug === slug);
+      if (index !== -1) {
+        return {
+          page: pages[index]!,
+          metadata: metadataList[index]!,
+        };
+      }
+      cursor = next_cursor;
+    } while (cursor);
+
+    return null;
   },
 );
 
@@ -115,15 +214,17 @@ export const getPageBlocks = cache(
         : undefined;
     } while (cursor);
 
-    const blocksWithChildren = await Promise.all(
-      blocks.map(async (block) => {
+    const blocksWithChildren = await mapPool(
+      blocks,
+      PAGE_BLOCKS_FETCH_CONCURRENCY,
+      async (block) => {
         if (!block.has_children) return block;
 
         return {
           ...block,
           children: await getPageBlocks(block.id),
         };
-      }),
+      },
     );
 
     return formatBlockWithChildren(blocksWithChildren);


### PR DESCRIPTION
## Summary

This branch bundles UX and reliability improvements across the site.

### Theme and layout
- Add a theme toggle using `next-themes` for light/dark/system preference.

### Notion and performance
- Cache Notion page blocks and improve date formatting with semantic dates.
- ISR for Notion pages (10s revalidation) and faster slug resolution and image loading.

### Accessibility and polish
- Improve accessibility and skip-link visibility.
- Align `HeroSkeleton` with the hero layout; add Suspense streaming and route loading skeletons.

### Tooling
- Track `.env.example`; ignore `.env` and `.env*.local` for local secrets.

## Target branch

`dev` (pre-production).

## Checklist
- [x] TypeScript and lint clean locally
- [x] No secrets committed

Made with [Cursor](https://cursor.com)