### PR TITLE
feat: RSS feeds, sitemap timestamps, and Notion-backed metadata

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,7 +1,6 @@
 import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
-import { getPageData } from "@/services/notion";
-import { formatPageMetadata } from "@/utils/formatter";
+import { metadataFromNotionPageId } from "@/utils/metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { AboutContent } from "../_components/about-content";
@@ -10,26 +9,7 @@ import { AboutHero } from "../_components/about-hero";
 export const revalidate = 10;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const page = await getPageData(process.env.NOTION_PAGE_ABOUT_ID!);
-  const meta = formatPageMetadata(page);
-  const ogImage = meta.thumbnail ?? "/logo.svg";
-  return {
-    title: meta.title,
-    description: meta.description,
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: "website",
-      images: [{ url: ogImage }],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: meta.title,
-      description: meta.description,
-      images: [ogImage],
-    },
-  };
+  return metadataFromNotionPageId(process.env.NOTION_PAGE_ABOUT_ID!);
 }
 
 export default function AboutPage() {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {
   getAllPublishedSlugsForStaticParams,
   getDatabasePageBySlug,
 } from "@/services/notion";
+import { buildShareMetadata } from "@/utils/share-metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { BlogJsonLd } from "./_components/blog-json-ld";
@@ -31,25 +32,17 @@ export async function generateMetadata({
   if (!found) {
     return { title: "Post not found" };
   }
-  const ogImage = found.metadata.thumbnail ?? "/logo.svg";
-  return {
-    title: found.metadata.title,
-    description: found.metadata.description,
-    openGraph: {
+  return buildShareMetadata(
+    {
       title: found.metadata.title,
       description: found.metadata.description,
-      type: "article",
+      thumbnail: found.metadata.thumbnail,
+    },
+    {
+      openGraphType: "article",
       publishedTime: found.metadata.published_date,
-      images: [{ url: ogImage }],
     },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: found.metadata.title,
-      description: found.metadata.description,
-      images: [ogImage],
-    },
-  };
+  );
 }
 
 export default function BlogPostPage({

--- a/src/app/blog/feed.xml/route.ts
+++ b/src/app/blog/feed.xml/route.ts
@@ -1,0 +1,25 @@
+import { getAllPublishedPostsForFeed } from "@/services/notion";
+import { buildRssDocument, rssItemsFromPosts } from "@/utils/rss";
+
+export const revalidate = 10;
+
+export async function GET() {
+  const base = process.env.BASE_URL!;
+  const origin = base.replace(/\/$/, "");
+  const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
+  const posts = await getAllPublishedPostsForFeed(databaseId, "Blog");
+  const xml = buildRssDocument({
+    title: "Nubelson Fernandes — Blog",
+    link: `${origin}/blog`,
+    description: "Writing and notes from Nubelson Fernandes.",
+    selfUrl: `${origin}/blog/feed.xml`,
+    items: rssItemsFromPosts(base, "/blog", posts),
+  });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "s-maxage=10, stale-while-revalidate",
+    },
+  });
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,6 @@
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
 import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
-import { getPageData } from "@/services/notion";
-import { formatPageMetadata } from "@/utils/formatter";
+import { metadataFromNotionPageId } from "@/utils/metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { BlogHero } from "../_components/blog-hero";
@@ -10,26 +9,7 @@ import { BlogPosts } from "../_components/blog-posts";
 export const revalidate = 10;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const page = await getPageData(process.env.NOTION_PAGE_BLOG_ID!);
-  const meta = formatPageMetadata(page);
-  const ogImage = meta.thumbnail ?? "/logo.svg";
-  return {
-    title: meta.title,
-    description: meta.description,
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: "website",
-      images: [{ url: ogImage }],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: meta.title,
-      description: meta.description,
-      images: [ogImage],
-    },
-  };
+  return metadataFromNotionPageId(process.env.NOTION_PAGE_BLOG_ID!);
 }
 
 export default function BlogPage() {

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,39 @@
+import { getAllPublishedPostsForFeed } from "@/services/notion";
+import {
+  buildRssDocument,
+  rssItemsFromPosts,
+  type RssFeedItem,
+} from "@/utils/rss";
+
+export const revalidate = 10;
+
+export async function GET() {
+  const base = process.env.BASE_URL!;
+  const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
+  const [blogPosts, workPosts] = await Promise.all([
+    getAllPublishedPostsForFeed(databaseId, "Blog"),
+    getAllPublishedPostsForFeed(databaseId, "Project"),
+  ]);
+
+  const items: RssFeedItem[] = [
+    ...rssItemsFromPosts(base, "/blog", blogPosts),
+    ...rssItemsFromPosts(base, "/work", workPosts),
+  ].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+
+  const origin = base.replace(/\/$/, "");
+  const selfUrl = `${origin}/feed.xml`;
+  const xml = buildRssDocument({
+    title: "Nubelson Fernandes — Blog & Work",
+    link: origin,
+    description: "Latest writing and projects from Nubelson Fernandes.",
+    selfUrl,
+    items,
+  });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "s-maxage=10, stale-while-revalidate",
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 import { JsonLd } from "@/components/json-ld";
 import { SkipLink } from "@/components/skip-link";
+import { TWITTER_CREATOR_HANDLE } from "@/utils/share-metadata";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
 import { Geist, Geist_Mono } from "next/font/google";
@@ -24,6 +25,15 @@ export const metadata: Metadata = {
     default: "Nubelson Fernandes",
   },
   description: "Designer and developer sharing work, writing, and tools.",
+  alternates: {
+    types: {
+      "application/rss+xml": [
+        { url: "/feed.xml", title: "Blog & work" },
+        { url: "/blog/feed.xml", title: "Blog" },
+        { url: "/work/feed.xml", title: "Work" },
+      ],
+    },
+  },
   openGraph: {
     siteName: "Nubelson Fernandes",
     locale: "en_US",
@@ -32,7 +42,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    creator: "@nublson",
+    creator: TWITTER_CREATOR_HANDLE,
     images: ["/logo.svg"],
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,7 @@
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
 import { PostsSectionSkeleton } from "@/components/skeletons/posts-section-skeleton";
 import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
-import { getPageData } from "@/services/notion";
-import { formatPageMetadata } from "@/utils/formatter";
+import { metadataFromNotionPageId } from "@/utils/metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { HomeHero } from "./_components/home-hero";
@@ -12,26 +11,9 @@ import { HomeProjects } from "./_components/home-projects";
 export const revalidate = 10;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const page = await getPageData(process.env.NOTION_PAGE_HOME_ID!);
-  const meta = formatPageMetadata(page);
-  const ogImage = meta.thumbnail ?? "/logo.svg";
-  return {
-    title: { absolute: meta.title },
-    description: meta.description,
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: "website",
-      images: [{ url: ogImage }],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: meta.title,
-      description: meta.description,
-      images: [ogImage],
-    },
-  };
+  return metadataFromNotionPageId(process.env.NOTION_PAGE_HOME_ID!, {
+    absoluteTitle: true,
+  });
 }
 
 export default function Home() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,40 +1,78 @@
-import { getAllPublishedSlugsForStaticParams } from "@/services/notion";
+import {
+  getAboutPageLastModified,
+  getAllPublishedEntriesForSitemap,
+  type PublishedSitemapEntry,
+} from "@/services/notion";
 import type { MetadataRoute } from "next";
+
+function maxLastModified(dates: Date[]): Date {
+  if (dates.length === 0) return new Date();
+  return new Date(Math.max(...dates.map((d) => d.getTime())));
+}
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const base = process.env.BASE_URL!;
+  const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
 
-  const [blogSlugs, workSlugs] = await Promise.all([
-    getAllPublishedSlugsForStaticParams(
-      process.env.NOTION_DATABASE_CONTENT_ID!,
-      "Blog",
-    ),
-    getAllPublishedSlugsForStaticParams(
-      process.env.NOTION_DATABASE_CONTENT_ID!,
-      "Project",
-    ),
+  const [blogEntries, workEntries, aboutLastModified] = await Promise.all([
+    getAllPublishedEntriesForSitemap(databaseId, "Blog"),
+    getAllPublishedEntriesForSitemap(databaseId, "Project"),
+    getAboutPageLastModified(),
   ]);
 
-  const staticRoutes = ["/", "/about", "/blog", "/work"].map((path) => ({
+  const blogDates = blogEntries.map(
+    (e: PublishedSitemapEntry) => e.lastModified,
+  );
+  const workDates = workEntries.map(
+    (e: PublishedSitemapEntry) => e.lastModified,
+  );
+  const homeDates = [
+    ...blogDates,
+    ...workDates,
+    ...(aboutLastModified ? [aboutLastModified] : []),
+  ];
+
+  const staticRoutes = [
+    {
+      path: "/",
+      lastModified: maxLastModified(homeDates),
+    },
+    {
+      path: "/about",
+      lastModified: aboutLastModified ?? new Date(),
+    },
+    {
+      path: "/blog",
+      lastModified: maxLastModified(blogDates),
+    },
+    {
+      path: "/work",
+      lastModified: maxLastModified(workDates),
+    },
+  ].map(({ path, lastModified }) => ({
     url: `${base}${path}`,
-    lastModified: new Date(),
+    lastModified,
     changeFrequency: "weekly" as const,
     priority: path === "/" ? 1 : 0.8,
   }));
 
-  const blogRoutes = blogSlugs.map(({ slug }) => ({
-    url: `${base}/blog/${slug}`,
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
+  const blogRoutes = blogEntries.map(
+    ({ slug, lastModified }: PublishedSitemapEntry) => ({
+      url: `${base}/blog/${slug}`,
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }),
+  );
 
-  const workRoutes = workSlugs.map(({ slug }) => ({
-    url: `${base}/work/${slug}`,
-    lastModified: new Date(),
-    changeFrequency: "monthly" as const,
-    priority: 0.6,
-  }));
+  const workRoutes = workEntries.map(
+    ({ slug, lastModified }: PublishedSitemapEntry) => ({
+      url: `${base}/work/${slug}`,
+      lastModified,
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    }),
+  );
 
   return [...staticRoutes, ...blogRoutes, ...workRoutes];
 }

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -4,6 +4,7 @@ import {
   getAllPublishedSlugsForStaticParams,
   getDatabasePageBySlug,
 } from "@/services/notion";
+import { buildShareMetadata } from "@/utils/share-metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { WorkJsonLd } from "./_components/work-json-ld";
@@ -31,24 +32,17 @@ export async function generateMetadata({
   if (!found) {
     return { title: "Project not found" };
   }
-  const ogImage = found.metadata.thumbnail ?? "/logo.svg";
-  return {
-    title: found.metadata.title,
-    description: found.metadata.description,
-    openGraph: {
+  return buildShareMetadata(
+    {
       title: found.metadata.title,
       description: found.metadata.description,
-      type: "website",
-      images: [{ url: ogImage }],
+      thumbnail: found.metadata.thumbnail,
     },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: found.metadata.title,
-      description: found.metadata.description,
-      images: [ogImage],
+    {
+      openGraphType: "article",
+      publishedTime: found.metadata.published_date,
     },
-  };
+  );
 }
 
 export default function WorkPostPage({
@@ -59,7 +53,9 @@ export default function WorkPostPage({
   return (
     <>
       <WorkJsonLd params={params} />
-      <Suspense fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}>
+      <Suspense
+        fallback={<HeroSkeleton showThumbnail showTopNav size="small" />}
+      >
         <WorkPostHero params={params} />
       </Suspense>
       <Suspense fallback={<ContentSectionSkeleton />}>

--- a/src/app/work/feed.xml/route.ts
+++ b/src/app/work/feed.xml/route.ts
@@ -1,0 +1,25 @@
+import { getAllPublishedPostsForFeed } from "@/services/notion";
+import { buildRssDocument, rssItemsFromPosts } from "@/utils/rss";
+
+export const revalidate = 10;
+
+export async function GET() {
+  const base = process.env.BASE_URL!;
+  const origin = base.replace(/\/$/, "");
+  const databaseId = process.env.NOTION_DATABASE_CONTENT_ID!;
+  const posts = await getAllPublishedPostsForFeed(databaseId, "Project");
+  const xml = buildRssDocument({
+    title: "Nubelson Fernandes — Work",
+    link: `${origin}/work`,
+    description: "Selected projects and case studies.",
+    selfUrl: `${origin}/work/feed.xml`,
+    items: rssItemsFromPosts(base, "/work", posts),
+  });
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      "Cache-Control": "s-maxage=10, stale-while-revalidate",
+    },
+  });
+}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,8 +1,7 @@
 import { ContentSectionSkeleton } from "@/components/skeletons/content-section-skeleton";
 import { HeroSkeleton } from "@/components/skeletons/hero-skeleton";
 import { ProjectsSectionSkeleton } from "@/components/skeletons/projects-section-skeleton";
-import { getPageData } from "@/services/notion";
-import { formatPageMetadata } from "@/utils/formatter";
+import { metadataFromNotionPageId } from "@/utils/metadata";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { WorkBody } from "../_components/work-body";
@@ -12,26 +11,7 @@ import { WorkProjects } from "../_components/work-projects";
 export const revalidate = 10;
 
 export async function generateMetadata(): Promise<Metadata> {
-  const page = await getPageData(process.env.NOTION_PAGE_WORK_ID!);
-  const meta = formatPageMetadata(page);
-  const ogImage = meta.thumbnail ?? "/logo.svg";
-  return {
-    title: meta.title,
-    description: meta.description,
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: "website",
-      images: [{ url: ogImage }],
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: "@nublson",
-      title: meta.title,
-      description: meta.description,
-      images: [ogImage],
-    },
-  };
+  return metadataFromNotionPageId(process.env.NOTION_PAGE_WORK_ID!);
 }
 
 export default function WorkPage() {

--- a/src/services/notion.tsx
+++ b/src/services/notion.tsx
@@ -1,5 +1,9 @@
 import { mapPool } from "@/lib/map-pool";
-import { formatBlockWithChildren, formatPostMetadata } from "@/utils/formatter";
+import {
+  formatBlockWithChildren,
+  formatPostMetadata,
+  type PostMetadata,
+} from "@/utils/formatter";
 import {
   BlockObjectResponse,
   Client,
@@ -113,6 +117,39 @@ export const getDatabasePages = cache(
   },
 );
 
+export type PublishedSitemapEntry = {
+  slug: string;
+  lastModified: Date;
+};
+
+/**
+ * All published rows with Notion `last_edited_time` (paginates past the first 100).
+ * @see getDatabasePageBySlug — same pagination for runtime slug resolution.
+ */
+async function getAllPublishedEntriesWithTimestamps(
+  databaseId: string,
+  media: keyof typeof mediaMap,
+): Promise<PublishedSitemapEntry[]> {
+  const out: PublishedSitemapEntry[] = [];
+  let cursor: string | undefined;
+  do {
+    const { pages, next_cursor } = await queryPublishedPagesPage(
+      databaseId,
+      mediaMap[media],
+      { pageSize: QUERY_PAGE_SIZE, start_cursor: cursor },
+    );
+    const metadataList = formatPostMetadata(pages);
+    for (let i = 0; i < pages.length; i++) {
+      out.push({
+        slug: metadataList[i]!.slug,
+        lastModified: new Date(pages[i]!.last_edited_time),
+      });
+    }
+    cursor = next_cursor;
+  } while (cursor);
+  return out;
+}
+
 /**
  * All published rows for static params (paginates past the first 100).
  * @see getDatabasePageBySlug — same pagination for runtime slug resolution.
@@ -121,7 +158,27 @@ export async function getAllPublishedSlugsForStaticParams(
   databaseId: string,
   media: keyof typeof mediaMap,
 ): Promise<{ slug: string }[]> {
-  const out: { slug: string }[] = [];
+  const entries = await getAllPublishedEntriesWithTimestamps(databaseId, media);
+  return entries.map(({ slug }) => ({ slug }));
+}
+
+/** Same pages as static params, including `lastModified` from Notion for sitemaps. */
+export function getAllPublishedEntriesForSitemap(
+  databaseId: string,
+  media: keyof typeof mediaMap,
+): Promise<PublishedSitemapEntry[]> {
+  return getAllPublishedEntriesWithTimestamps(databaseId, media);
+}
+
+/**
+ * All published posts for RSS (paginates past the first 100), newest first.
+ * @see getAllPublishedEntriesWithTimestamps — same query and ordering.
+ */
+export async function getAllPublishedPostsForFeed(
+  databaseId: string,
+  media: keyof typeof mediaMap,
+): Promise<PostMetadata[]> {
+  const out: PostMetadata[] = [];
   let cursor: string | undefined;
   do {
     const { pages, next_cursor } = await queryPublishedPagesPage(
@@ -129,10 +186,22 @@ export async function getAllPublishedSlugsForStaticParams(
       mediaMap[media],
       { pageSize: QUERY_PAGE_SIZE, start_cursor: cursor },
     );
-    out.push(...formatPostMetadata(pages).map((p) => ({ slug: p.slug })));
+    out.push(...formatPostMetadata(pages));
     cursor = next_cursor;
   } while (cursor);
   return out;
+}
+
+/** `NOTION_PAGE_ABOUT_ID` last edit time when configured and retrievable. */
+export async function getAboutPageLastModified(): Promise<Date | null> {
+  const id = process.env.NOTION_PAGE_ABOUT_ID?.trim();
+  if (!id) return null;
+  try {
+    const page = await getPageData(id);
+    return new Date(page.last_edited_time);
+  } catch {
+    return null;
+  }
 }
 
 /** Resolves a published database row by URL slug (derived from the page title). */

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,0 +1,23 @@
+import { getPageData } from "@/services/notion";
+import { formatPageMetadata } from "@/utils/formatter";
+import {
+  buildShareMetadata,
+  type ShareMetadataOptions,
+} from "@/utils/share-metadata";
+
+/** Metadata for static routes backed by a single Notion page (cover URL from page). */
+export async function metadataFromNotionPageId(
+  notionPageId: string,
+  options?: ShareMetadataOptions,
+): Promise<ReturnType<typeof buildShareMetadata>> {
+  const page = await getPageData(notionPageId);
+  const meta = formatPageMetadata(page);
+  return buildShareMetadata(
+    {
+      title: meta.title,
+      description: meta.description,
+      thumbnail: meta.thumbnail,
+    },
+    options,
+  );
+}

--- a/src/utils/rss.ts
+++ b/src/utils/rss.ts
@@ -1,0 +1,89 @@
+import type { PostMetadata } from "@/utils/formatter";
+
+export type RssFeedItem = {
+  title: string;
+  link: string;
+  description: string;
+  pubDate: Date;
+};
+
+function pubDateForPost(post: PostMetadata): Date {
+  const raw = post.published_date?.trim();
+  if (raw) {
+    const d = new Date(raw);
+    if (!Number.isNaN(d.getTime())) return d;
+  }
+  return new Date(post.updated_date);
+}
+
+/** Map Notion post metadata to RSS items (absolute links). */
+export function rssItemsFromPosts(
+  baseUrl: string,
+  pathPrefix: "/blog" | "/work",
+  posts: PostMetadata[],
+): RssFeedItem[] {
+  const base = baseUrl.replace(/\/$/, "");
+  return posts.map((post) => ({
+    title: post.title,
+    link: `${base}${pathPrefix}/${post.slug}`,
+    description: post.description.trim() || post.title,
+    pubDate: pubDateForPost(post),
+  }));
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+/** RFC 822 / RFC 1123 date for RSS 2.0 `pubDate`. */
+export function toRssPubDate(date: Date): string {
+  return date.toUTCString();
+}
+
+export function buildRssDocument(options: {
+  title: string;
+  link: string;
+  description: string;
+  selfUrl: string;
+  language?: string;
+  items: RssFeedItem[];
+}): string {
+  const language = options.language ?? "en-us";
+  const lastBuild =
+    options.items.length > 0
+      ? new Date(
+          Math.max(...options.items.map((i) => i.pubDate.getTime())),
+        )
+      : new Date();
+
+  const itemXml = options.items
+    .map((item) => {
+      const guid = item.link;
+      return `
+    <item>
+      <title>${escapeXml(item.title)}</title>
+      <link>${escapeXml(item.link)}</link>
+      <description>${escapeXml(item.description)}</description>
+      <pubDate>${escapeXml(toRssPubDate(item.pubDate))}</pubDate>
+      <guid isPermaLink="true">${escapeXml(guid)}</guid>
+    </item>`;
+    })
+    .join("");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(options.title)}</title>
+    <link>${escapeXml(options.link)}</link>
+    <description>${escapeXml(options.description)}</description>
+    <language>${escapeXml(language)}</language>
+    <lastBuildDate>${escapeXml(toRssPubDate(lastBuild))}</lastBuildDate>
+    <atom:link href="${escapeXml(options.selfUrl)}" rel="self" type="application/rss+xml" />${itemXml}
+  </channel>
+</rss>`;
+}

--- a/src/utils/share-metadata.ts
+++ b/src/utils/share-metadata.ts
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+
+export const TWITTER_CREATOR_HANDLE = "@nublson";
+
+const DEFAULT_OG_IMAGE = "/logo.svg";
+
+export type ShareMetadataInput = {
+  title: string;
+  description: string;
+  thumbnail?: string;
+};
+
+export type ShareMetadataOptions = {
+  /** Skip layout `title.template` suffix (used for home). */
+  absoluteTitle?: boolean;
+  openGraphType?: "website" | "article";
+  publishedTime?: string;
+};
+
+export function buildShareMetadata(
+  { title, description, thumbnail }: ShareMetadataInput,
+  options?: ShareMetadataOptions,
+): Metadata {
+  const ogImage = thumbnail ?? DEFAULT_OG_IMAGE;
+  const openGraphType = options?.openGraphType ?? "website";
+
+  return {
+    title: options?.absoluteTitle ? { absolute: title } : title,
+    description,
+    openGraph: {
+      title,
+      description,
+      type: openGraphType,
+      images: [{ url: ogImage }],
+      ...(options?.publishedTime
+        ? { publishedTime: options.publishedTime }
+        : {}),
+    },
+    twitter: {
+      card: "summary_large_image",
+      creator: TWITTER_CREATOR_HANDLE,
+      title,
+      description,
+      images: [ogImage],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds RSS 2.0 feeds (site-wide, blog-only, work-only), improves the sitemap with Notion `last_edited_time` for published pages, and centralizes Open Graph / Twitter metadata via shared helpers with `generateMetadata` backed by Notion for key routes.

## Commits

1. **feat: add share metadata builder for Open Graph and Twitter** — `src/utils/share-metadata.ts`
2. **feat: add RSS 2.0 builder and post-to-item mapping** — `src/utils/rss.ts`
3. **feat: paginate Notion for RSS posts and sitemap lastModified** — `src/services/notion.tsx`
4. **feat: add Notion page helper for generateMetadata** — `src/utils/metadata.ts`
5. **feat: add combined and section RSS feeds at feed.xml routes** — `/feed.xml`, `/blog/feed.xml`, `/work/feed.xml`
6. **feat: use Notion last_edited_time in sitemap entries** — `src/app/sitemap.ts`
7. **feat: derive page metadata from Notion and link RSS in layout** — root layout + home, about, blog, work, and slug pages

## Notes

- Integration branch for this repo is `dev` (no remote `develop`).
- Requires `BASE_URL`, `NOTION_DATABASE_CONTENT_ID`, and existing Notion page env vars; `NOTION_PAGE_ABOUT_ID` improves about/home sitemap dates when set.

## Verification

- `npm run build` passes locally.

Made with [Cursor](https://cursor.com)