### PR TITLE
docs: add DESIGN.md for architecture and Notion content model

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,166 @@
+# Design
+
+This document describes how **nublson-v3** is structured: architecture, content model, caching, and UI conventions. It is meant for contributors and future refactors—not end users.
+
+## Purpose
+
+A personal site for **work**, **blog**, and **about** content. Copy and structure live primarily in **Notion**; Next.js fetches via the Notion API, renders React Server Components, and exposes RSS feeds, sitemaps, and Open Graph metadata.
+
+## Tech stack
+
+| Layer | Choice |
+|--------|--------|
+| Framework | [Next.js](https://nextjs.org/) 16 (App Router) |
+| UI | React 19, Server Components by default |
+| Styling | Tailwind CSS 4, CSS variables for theming |
+| Components | [shadcn/ui](https://ui.shadcn.com/) (style: **radix-nova**, base color **neutral**) |
+| Icons | Lucide React, Remix Icon where needed |
+| Content API | `@notionhq/client` |
+| Block rendering | `@9gustin/react-notion-render` + custom blocks in `src/components/content-blocks.tsx` |
+| Theme | `next-themes` (class-based, system default) |
+| Fonts | Geist Sans / Geist Mono (`next/font/google`) |
+| Tests | Vitest + Testing Library |
+
+Package manager: **pnpm** (see `package.json`).
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+  subgraph client [Browser]
+    UI[Pages and layouts]
+  end
+  subgraph next [Next.js app]
+    RSC[Server Components]
+    RouteHandlers[Route handlers]
+    Cache["Next cache\n(unstable_cache + ISR)"]
+  end
+  subgraph external [External]
+    Notion[Notion API]
+  end
+  UI --> RSC
+  RSC --> Cache
+  Cache --> Notion
+  RouteHandlers --> Cache
+  RouteHandlers --> Notion
+```
+
+- **All Notion reads** go through `src/services/notion.tsx` (plus formatters in `src/utils/formatter.ts`).
+- **Block trees** are fetched with bounded concurrency (`src/lib/map-pool.ts`) and depth limits to respect Notion rate limits and payload size.
+- **On-demand updates** use `POST /api/revalidate` to invalidate cached Notion data or specific paths (see [Cache and revalidation](#cache-and-revalidation)).
+
+## Repository layout
+
+| Path | Role |
+|------|------|
+| `src/app/` | App Router: routes, `layout.tsx`, `loading.tsx`, route handlers (`feed.xml`, `api/revalidate`), SEO helpers (`sitemap.ts`, `robots.ts`) |
+| `src/app/_components/` | Route-local components for home, about, blog listing, work listing |
+| `src/app/blog/[slug]/`, `src/app/work/[slug]/` | Dynamic entries + co-located `_components/` |
+| `src/components/` | Shared UI: header, footer, notion-driven content blocks, skeletons |
+| `src/sections/` | Larger compositions (e.g. main content section wrapping Notion render) |
+| `src/services/notion.tsx` | Notion client, queries, caching wrappers |
+| `src/lib/` | Shared utilities (`cn`, `map-pool`) |
+| `src/utils/` | Formatters, metadata builders, RSS helpers |
+| `components.json` | shadcn config (aliases, Tailwind entry: `src/app/globals.css`) |
+
+Path alias: `@/*` → `src/*` (`tsconfig.json`).
+
+## Routing map
+
+| URL | Source |
+|-----|--------|
+| `/` | Home: hero + projects + posts from Notion |
+| `/about` | About page blocks from Notion |
+| `/blog` | Blog index |
+| `/blog/[slug]` | Blog post (content DB, `Media = Blog`) |
+| `/work` | Work index |
+| `/work/[slug]` | Work entry (`Media = Project`) |
+| `/feed.xml` | Combined RSS |
+| `/blog/feed.xml`, `/work/feed.xml` | Section RSS |
+| `POST /api/revalidate` | Cache invalidation (secret query param) |
+
+## Content model (Notion)
+
+The app expects **Notion databases** and **fixed pages** referenced by environment variables (see `.env.example`).
+
+### Published rows
+
+Indexed content is queried with filters aligned to `src/services/notion.tsx`:
+
+- **`Media`** (select): `Blog` or `Project`—separates blog posts vs. portfolio work in the shared content database.
+- **`State`** (select): `Done`—only published items appear in listings, feeds, and static params.
+
+Posts are sorted by **`Publish Date`** (descending). Metadata such as title, description, dates, and thumbnails is normalized in `src/utils/formatter.ts` (`formatPostMetadata`, etc.).
+
+### Slugs
+
+Default slug behavior is derived from the page **title** (see formatter). Optionally, set **`NOTION_SLUG_PROPERTY`** to a rich_text property name on the database so slug lookup uses a filtered query instead of scanning pages.
+
+### Static page IDs
+
+Hero and SEO for section roots use single Notion pages:
+
+- `NOTION_PAGE_HOME_ID`, `NOTION_PAGE_ABOUT_ID`, `NOTION_PAGE_WORK_ID`, `NOTION_PAGE_BLOG_ID`
+
+`metadataFromNotionPageId` in `src/utils/metadata.ts` loads cover images and titles from those pages.
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `BASE_URL` | Canonical site URL (metadata, RSS links) |
+| `NOTION_ACCESS_TOKEN` | Notion integration token |
+| `NOTION_DATABASE_CONTENT_ID` | Main database for blog + work entries |
+| `NOTION_DATABASE_GEARS_ID` | Reserved for future / gears content (see `.env.example`) |
+| `NOTION_PAGE_*` | Notion page IDs for static sections |
+| `NOTION_SLUG_PROPERTY` | Optional: rich_text property for URL slugs |
+| `REVALIDATION_SECRET` | Shared secret for `POST /api/revalidate` |
+
+## Cache and revalidation
+
+### Route segment config
+
+Several routes set `export const revalidate = 10` (seconds ISR). Adjust per route if you need fresher or cheaper builds.
+
+### Tagged cache for blocks
+
+`getPageBlocks` wraps recursive block fetching in `unstable_cache` with tag **`notion-blocks`** and the same revalidate window. Listing queries use React `cache()` for deduplication within a request.
+
+### Webhook-style refresh
+
+`POST /api/revalidate`:
+
+- Query: `?secret=<REVALIDATION_SECRET>`
+- Body (optional JSON): `{ "type": "blog" \| "work", "slug": "..." }` revalidates that post path.
+- Without a targeted slug: **`revalidateTag("notion-blocks")`** and **`revalidatePath("/", "layout")`** for a broad refresh.
+
+Wire this URL from Notion automations or your deployment pipeline when content changes.
+
+## UI and theming
+
+- **Shell**: `Header`, `Footer`, `SkipLink`, main landmark `#main-content` in `src/app/layout.tsx`.
+- **Dark mode**: `ThemeProvider` from `next-themes`; `.dark` variant defined in `globals.css`.
+- **Design tokens**: shadcn/Tailwind theme via CSS variables (`--background`, `--primary`, `--radius`, etc.) in `src/app/globals.css`; chart and sidebar tokens are present for shadcn component compatibility.
+- **Wrapper layout**: Pages use a `.wrapper` class for horizontal rhythm (see layout/main).
+
+Prefer existing primitives under `src/components/ui/` when adding interactive UI.
+
+## SEO and feeds
+
+- **Metadata**: `generateMetadata` / `metadataFromNotionPageId` / `buildShareMetadata` for titles, descriptions, images, article times.
+- **Structured data**: JSON-LD components for posts (`blog-json-ld`, `work-json-ld`, site `WebSite` in layout).
+- **Discovery**: `sitemap.ts`, `robots.ts`, RSS builders in `src/utils/rss.ts`.
+- **Images**: Remote patterns for Notion and common hosts are listed in `next.config.ts` under `images.remotePatterns`.
+
+## Testing
+
+- `pnpm test` — Vitest unit tests (`*.test.ts` / `*.test.tsx`).
+- `pnpm type-check` — TypeScript.
+- `pnpm lint` — ESLint (Next.js config).
+
+Add tests beside the module (`map-pool.test.ts`, `formatter.test.ts`, etc.).
+
+## Related docs
+
+- Next.js behavior in this repo may differ from older majors; check `node_modules/next/dist/docs/` when upgrading or using new APIs.
+- `README.md` in this repository is a GitHub profile readme, not project runbook—use `package.json` scripts and `.env.example` for local setup.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,166 +1,182 @@
-# Design
+---
+version: alpha
+name: Nubelson Fernandes
+description: Neutral, editorial personal site — shadcn radix-nova on Geist. Content from Notion; UI is calm typography and generous whitespace.
+colors:
+  primary: "#252525"
+  secondary: "#8e8e8e"
+  tertiary: "#b5b5b5"
+  neutral: "#ffffff"
+  on-primary: "#fafafa"
+  muted-surface: "#f7f7f7"
+  border: "#ebebeb"
+  destructive: "#dc2626"
+typography:
+  display-xl:
+    fontFamily: Geist Sans
+    fontSize: 6.25rem
+    fontWeight: 600
+    lineHeight: 1.2em
+    letterSpacing: "-0.05em"
+  display-lg:
+    fontFamily: Geist Sans
+    fontSize: 5rem
+    fontWeight: 600
+    lineHeight: 1.2em
+    letterSpacing: "-0.03em"
+  title-md:
+    fontFamily: Geist Sans
+    fontSize: 2rem
+    fontWeight: 600
+    lineHeight: 1.6em
+    letterSpacing: "-0.02em"
+  body-lg:
+    fontFamily: Geist Sans
+    fontSize: 1.125rem
+    fontWeight: 400
+    lineHeight: 1.6em
+    letterSpacing: "-0.02em"
+  body-md:
+    fontFamily: Geist Sans
+    fontSize: 1rem
+    fontWeight: 400
+    lineHeight: 1.6em
+    letterSpacing: "-0.02em"
+  body-sm:
+    fontFamily: Geist Sans
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.6em
+    letterSpacing: "-0.02em"
+  mono-sm:
+    fontFamily: Geist Mono
+    fontSize: 0.875rem
+    fontWeight: 400
+    lineHeight: 1.5em
+rounded:
+  sm: 6px
+  md: 8px
+  lg: 10px
+spacing:
+  xs: 12px
+  sm: 16px
+  md: 20px
+  lg: 60px
+  section: 60px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.lg}"
+    padding: 10px
+  button-primary-hover:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.on-primary}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.lg}"
+    padding: 10px
+  button-outline:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.primary}"
+    typography: "{typography.body-sm}"
+    rounded: "{rounded.lg}"
+    padding: 10px
+  card-content:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.primary}"
+    rounded: "{rounded.lg}"
+---
 
-This document describes how **nublson-v3** is structured: architecture, content model, caching, and UI conventions. It is meant for contributors and future refactors—not end users.
+## Overview
 
-## Purpose
+This is the visual identity for **nublson-v3**, a portfolio and blog. The experience should feel like a **quiet editorial surface**: strong typographic hierarchy, a strictly **neutral grayscale palette**, and **no decorative noise**. Content (case studies, posts, bio copy) comes from **Notion**; the shell must stay out of the way and let long-form text and images read clearly.
 
-A personal site for **work**, **blog**, and **about** content. Copy and structure live primarily in **Notion**; Next.js fetches via the Notion API, renders React Server Components, and exposes RSS feeds, sitemaps, and Open Graph metadata.
+**Brand posture:** expert, approachable, craft-focused — closer to a design-engineering journal than a marketing landing page.
 
-## Tech stack
+**Stack note:** React Server Components, Tailwind CSS 4, shadcn/ui (*radix-nova*, base *neutral*), `next-themes` for light/dark. Tokens in `src/app/globals.css` use **OKLCH**; the hex values in the front matter above are **sRGB companions** for tooling and agents. Dark mode inverts contrast while preserving the same structure (see Colors).
 
-| Layer | Choice |
-|--------|--------|
-| Framework | [Next.js](https://nextjs.org/) 16 (App Router) |
-| UI | React 19, Server Components by default |
-| Styling | Tailwind CSS 4, CSS variables for theming |
-| Components | [shadcn/ui](https://ui.shadcn.com/) (style: **radix-nova**, base color **neutral**) |
-| Icons | Lucide React, Remix Icon where needed |
-| Content API | `@notionhq/client` |
-| Block rendering | `@9gustin/react-notion-render` + custom blocks in `src/components/content-blocks.tsx` |
-| Theme | `next-themes` (class-based, system default) |
-| Fonts | Geist Sans / Geist Mono (`next/font/google`) |
-| Tests | Vitest + Testing Library |
+## Colors
 
-Package manager: **pnpm** (see `package.json`).
+The palette is **achromatic**: no brand hue; emphasis comes from weight and size instead of color.
 
-## High-level architecture
+- **Primary (`#252525`):** Main ink — headlines, default button fills, and strong emphasis in light mode. Maps to semantic `--primary` / `--foreground` patterns in code.
+- **Secondary (`#8e8e8e`):** Supporting text — metadata, captions, secondary navigation. Maps to **muted** foreground usage.
+- **Tertiary (`#b5b5b5`):** De-emphasized chrome — dividers, inactive hints, subtle borders when a heavier border is too loud.
+- **Neutral (`#ffffff`):** Page canvas and card surfaces in light mode (`--background`, `--card`).
+- **On-primary (`#fafafa`):** Text and icons on primary-colored surfaces (e.g. filled buttons).
+- **Muted surface (`#f7f7f7`):** Hover and subtle fills (`--muted`, `--secondary` family).
+- **Border (`#ebebeb`):** Hairline structure (`--border`, `--input`).
+- **Destructive (`#dc2626`):** Errors and dangerous actions only — never for decoration.
 
-```mermaid
-flowchart LR
-  subgraph client [Browser]
-    UI[Pages and layouts]
-  end
-  subgraph next [Next.js app]
-    RSC[Server Components]
-    RouteHandlers[Route handlers]
-    Cache["Next cache\n(unstable_cache + ISR)"]
-  end
-  subgraph external [External]
-    Notion[Notion API]
-  end
-  UI --> RSC
-  RSC --> Cache
-  Cache --> Notion
-  RouteHandlers --> Cache
-  RouteHandlers --> Notion
-```
+**Dark mode:** Background approaches deep neutral charcoal; foreground and primary **swap roles** so primary surfaces read as light-on-dark. Never introduce a saturated accent color for CTAs — interaction states use **opacity**, **muted fills**, and **focus rings**, not new hues.
 
-- **All Notion reads** go through `src/services/notion.tsx` (plus formatters in `src/utils/formatter.ts`).
-- **Block trees** are fetched with bounded concurrency (`src/lib/map-pool.ts`) and depth limits to respect Notion rate limits and payload size.
-- **On-demand updates** use `POST /api/revalidate` to invalidate cached Notion data or specific paths (see [Cache and revalidation](#cache-and-revalidation)).
+## Typography
 
-## Repository layout
+**Geist Sans** is the single voice for UI and editorial content; **Geist Mono** is optional for code snippets or technical labels.
 
-| Path | Role |
-|------|------|
-| `src/app/` | App Router: routes, `layout.tsx`, `loading.tsx`, route handlers (`feed.xml`, `api/revalidate`), SEO helpers (`sitemap.ts`, `robots.ts`) |
-| `src/app/_components/` | Route-local components for home, about, blog listing, work listing |
-| `src/app/blog/[slug]/`, `src/app/work/[slug]/` | Dynamic entries + co-located `_components/` |
-| `src/components/` | Shared UI: header, footer, notion-driven content blocks, skeletons |
-| `src/sections/` | Larger compositions (e.g. main content section wrapping Notion render) |
-| `src/services/notion.tsx` | Notion client, queries, caching wrappers |
-| `src/lib/` | Shared utilities (`cn`, `map-pool`) |
-| `src/utils/` | Formatters, metadata builders, RSS helpers |
-| `components.json` | shadcn config (aliases, Tailwind entry: `src/app/globals.css`) |
+- **Display (`display-xl` / `display-lg`):** Hero names and major section titles — tight negative tracking, semibold, large responsive jumps (mobile vs. desktop). Implemented via `Typography` variants `h1`–`h2` in `src/components/typography.tsx`.
+- **Title (`title-md`):** Subheads and list titles (`h3`–`h4` variants).
+- **Body (`body-lg` / `body-md` / `body-sm`):** Default reading text uses **`body-md`**; intros and comfortable long-form can step up to **`body-lg`**. Metadata and compact UI use **`body-sm`**.
 
-Path alias: `@/*` → `src/*` (`tsconfig.json`).
+**Rules:** Prefer **`text-muted-foreground`** for secondary copy instead of lowering opacity on body text. Do not mix third-party display fonts — consistency matters more than novelty.
 
-## Routing map
+## Layout
 
-| URL | Source |
-|-----|--------|
-| `/` | Home: hero + projects + posts from Notion |
-| `/about` | About page blocks from Notion |
-| `/blog` | Blog index |
-| `/blog/[slug]` | Blog post (content DB, `Media = Blog`) |
-| `/work` | Work index |
-| `/work/[slug]` | Work entry (`Media = Project`) |
-| `/feed.xml` | Combined RSS |
-| `/blog/feed.xml`, `/work/feed.xml` | Section RSS |
-| `POST /api/revalidate` | Cache invalidation (secret query param) |
+- **Content width:** Primary column is **`max-width: 840px`**, centered — the `.wrapper` class in `globals.css`. This keeps line length readable for articles and case studies.
+- **Horizontal padding:** **`px-5`** (20px) on small screens so text never touches the viewport edge.
+- **Vertical rhythm:** Section stacks use **~60px** gaps (`gap-[60px]` on main, hero sections) so blocks breathe; within sections, use **16–24px** between related elements.
+- **Header:** Logo, primary nav, social icons, theme toggle — single horizontal row with vertical separators; keep density **compact** so content owns the fold.
 
-## Content model (Notion)
+## Elevation & Depth
 
-The app expects **Notion databases** and **fixed pages** referenced by environment variables (see `.env.example`).
+This system avoids heavy drop shadows. Depth is communicated through:
 
-### Published rows
+- **Subtle borders** (`border` token) and **flat layered surfaces** (card vs. page background).
+- **Focus rings** — `outline` using the **ring** color (`--ring`) for keyboard and skip-link visibility (WCAG-friendly).
+- **Skip link** on focus: light shadow only to lift the link above the page — see `.skip-link:focus-visible` in `globals.css`.
 
-Indexed content is queried with filters aligned to `src/services/notion.tsx`:
+Do not stack multiple shadow levels or use glassmorphism; it fights the neutral, print-like tone.
 
-- **`Media`** (select): `Blog` or `Project`—separates blog posts vs. portfolio work in the shared content database.
-- **`State`** (select): `Done`—only published items appear in listings, feeds, and static params.
+## Shapes
 
-Posts are sorted by **`Publish Date`** (descending). Metadata such as title, description, dates, and thumbnails is normalized in `src/utils/formatter.ts` (`formatPostMetadata`, etc.).
+- **Base radius:** **10px** (`--radius` / `rounded-lg`) for buttons, inputs, and cards — soft but not pill-shaped.
+- **Scale:** Smaller controls may use **`rounded-md`** (8px) or **`rounded-sm`** (6px) from the token scale.
+- **Media:** Cover and thumbnail images use **`rounded-lg`** to match cards; full-bleed heroes may stay square if the crop demands it.
 
-### Slugs
+## Components
 
-Default slug behavior is derived from the page **title** (see formatter). Optionally, set **`NOTION_SLUG_PROPERTY`** to a rich_text property name on the database so slug lookup uses a filtered query instead of scanning pages.
+- **Primary button:** Filled **`primary`** background, **`on-primary`** label, **`rounded-lg`**, compact height (~32px default size in `button` component). Hover darkens slightly via opacity (`bg-primary/80`), not a new color.
+- **Outline / ghost:** Use for secondary actions — **`neutral`** or transparent surface, **`primary`** or **`foreground`** text, visible border only when the outline variant requires separation from the background.
+- **Cards and lists:** Prefer **border + subtle background** over shadows; titles use **accent-foreground** / semibold patterns per existing sections.
+- **Navigation:** Text links and icons use **`muted-foreground`** default and **`foreground`** on hover — no underline on nav unless it is a content link inside prose.
 
-### Static page IDs
+## Do's and Don'ts
 
-Hero and SEO for section roots use single Notion pages:
+**Do**
 
-- `NOTION_PAGE_HOME_ID`, `NOTION_PAGE_ABOUT_ID`, `NOTION_PAGE_WORK_ID`, `NOTION_PAGE_BLOG_ID`
+- Reserve **destructive** color for real errors or irreversible actions.
+- Keep **one column** for reading flows; use grids only for project cards or comparable summaries.
+- Respect **focus-visible** styles for every interactive control.
+- Let **Notion-driven content** use the shared **`Typography`** and content-block components so RSS/HTML stay visually aligned.
 
-`metadataFromNotionPageId` in `src/utils/metadata.ts` loads cover images and titles from those pages.
+**Don't**
 
-### Environment variables
+- Add a rainbow accent or gradient hero — it breaks the neutral system.
+- Shrink body text below **`body-sm`** for main articles.
+- Use loud shadows or neon focus rings.
+- Hard-code pixel widths outside the **`wrapper`** / grid patterns already in the repo.
 
-| Variable | Purpose |
-|----------|---------|
-| `BASE_URL` | Canonical site URL (metadata, RSS links) |
-| `NOTION_ACCESS_TOKEN` | Notion integration token |
-| `NOTION_DATABASE_CONTENT_ID` | Main database for blog + work entries |
-| `NOTION_DATABASE_GEARS_ID` | Reserved for future / gears content (see `.env.example`) |
-| `NOTION_PAGE_*` | Notion page IDs for static sections |
-| `NOTION_SLUG_PROPERTY` | Optional: rich_text property for URL slugs |
-| `REVALIDATION_SECRET` | Shared secret for `POST /api/revalidate` |
+## Appendix: Implementation and codebase
 
-## Cache and revalidation
+This appendix is **not** part of the DESIGN.md visual spec; it documents how the product is built for contributors.
 
-### Route segment config
+**Architecture:** Next.js 16 App Router, Notion API via `src/services/notion.tsx`, ISR + `revalidateTag("notion-blocks")`, `POST /api/revalidate` with `REVALIDATION_SECRET`. Content filters: **Media** (`Blog` | `Project`), **State** = **Done**, sort by **Publish Date**.
 
-Several routes set `export const revalidate = 10` (seconds ISR). Adjust per route if you need fresher or cheaper builds.
+**Repository:** `src/app/` routes; `src/components/` shared UI; `components.json` shadcn config; path alias `@/*` → `src/*`.
 
-### Tagged cache for blocks
+**SEO:** RSS under `/feed.xml`, section feeds, `sitemap.ts`, JSON-LD components for posts and site.
 
-`getPageBlocks` wraps recursive block fetching in `unstable_cache` with tag **`notion-blocks`** and the same revalidate window. Listing queries use React `cache()` for deduplication within a request.
+**Commands:** `pnpm dev`, `pnpm build`, `pnpm test`, `pnpm lint`, `pnpm type-check`. Environment variables are listed in `.env.example`.
 
-### Webhook-style refresh
-
-`POST /api/revalidate`:
-
-- Query: `?secret=<REVALIDATION_SECRET>`
-- Body (optional JSON): `{ "type": "blog" \| "work", "slug": "..." }` revalidates that post path.
-- Without a targeted slug: **`revalidateTag("notion-blocks")`** and **`revalidatePath("/", "layout")`** for a broad refresh.
-
-Wire this URL from Notion automations or your deployment pipeline when content changes.
-
-## UI and theming
-
-- **Shell**: `Header`, `Footer`, `SkipLink`, main landmark `#main-content` in `src/app/layout.tsx`.
-- **Dark mode**: `ThemeProvider` from `next-themes`; `.dark` variant defined in `globals.css`.
-- **Design tokens**: shadcn/Tailwind theme via CSS variables (`--background`, `--primary`, `--radius`, etc.) in `src/app/globals.css`; chart and sidebar tokens are present for shadcn component compatibility.
-- **Wrapper layout**: Pages use a `.wrapper` class for horizontal rhythm (see layout/main).
-
-Prefer existing primitives under `src/components/ui/` when adding interactive UI.
-
-## SEO and feeds
-
-- **Metadata**: `generateMetadata` / `metadataFromNotionPageId` / `buildShareMetadata` for titles, descriptions, images, article times.
-- **Structured data**: JSON-LD components for posts (`blog-json-ld`, `work-json-ld`, site `WebSite` in layout).
-- **Discovery**: `sitemap.ts`, `robots.ts`, RSS builders in `src/utils/rss.ts`.
-- **Images**: Remote patterns for Notion and common hosts are listed in `next.config.ts` under `images.remotePatterns`.
-
-## Testing
-
-- `pnpm test` — Vitest unit tests (`*.test.ts` / `*.test.tsx`).
-- `pnpm type-check` — TypeScript.
-- `pnpm lint` — ESLint (Next.js config).
-
-Add tests beside the module (`map-pool.test.ts`, `formatter.test.ts`, etc.).
-
-## Related docs
-
-- Next.js behavior in this repo may differ from older majors; check `node_modules/next/dist/docs/` when upgrading or using new APIs.
-- `README.md` in this repository is a GitHub profile readme, not project runbook—use `package.json` scripts and `.env.example` for local setup.
+**Further reading:** [DESIGN.md format spec](https://github.com/google-labs-code/design.md) (Google Labs). Validate this file with `npx @google/design.md lint DESIGN.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR replaces the earlier architecture-focused draft with a file that follows the **Google Labs [DESIGN.md](https://github.com/google-labs-code/design.md) spec**:

- **YAML front matter** — `version`, `name`, `description`, semantic **colors**, **typography** scales aligned with `Typography` + Geist, **rounded** / **spacing**, and **components** that reference tokens (`button-primary`, outline, card).

- **Markdown body** in **canonical section order**: Overview → Colors → Typography → Layout → Elevation & Depth → Shapes → Components → Do's and Don'ts.

- **Appendix** at the end — engineering notes (Notion, revalidation, repo map, commands) kept separate so agents treat tokens + prose as the design source of truth.

Run **`pnpm dlx @google/design.md lint DESIGN.md`** (or `npx @google/design.md lint DESIGN.md`) locally to validate against the published linter when Node is available.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a1ffaea-761b-42bd-b11b-7c7cf292ca5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a1ffaea-761b-42bd-b11b-7c7cf292ca5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

