### PR TITLE
fix: harden notion content rendering and revalidation parsing

### DIFF
--- a/src/app/_components/about-content.tsx
+++ b/src/app/_components/about-content.tsx
@@ -1,9 +1,7 @@
 import ContentSection from "@/sections/content";
 import { getPageBlocks } from "@/services/notion";
-import { formatBlockWithChildren } from "@/utils/formatter";
 
 export async function AboutContent() {
-  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_ABOUT_ID!);
-  const pageContent = formatBlockWithChildren(pageBlocks);
+  const pageContent = await getPageBlocks(process.env.NOTION_PAGE_ABOUT_ID!);
   return <ContentSection blocks={pageContent} />;
 }

--- a/src/app/_components/work-body.tsx
+++ b/src/app/_components/work-body.tsx
@@ -1,9 +1,7 @@
 import ContentSection from "@/sections/content";
 import { getPageBlocks } from "@/services/notion";
-import { formatBlockWithChildren } from "@/utils/formatter";
 
 export async function WorkBody() {
-  const pageBlocks = await getPageBlocks(process.env.NOTION_PAGE_WORK_ID!);
-  const pageContent = formatBlockWithChildren(pageBlocks);
+  const pageContent = await getPageBlocks(process.env.NOTION_PAGE_WORK_ID!);
   return <ContentSection blocks={pageContent} />;
 }

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -7,10 +7,28 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
   }
 
-  const body = (await request.json().catch(() => ({}))) as {
-    type?: "blog" | "work";
-    slug?: string;
-  };
+  let body: { type?: "blog" | "work"; slug?: string } = {};
+  const rawBody = await request.text();
+
+  if (rawBody.trim().length > 0) {
+    try {
+      const parsedBody = JSON.parse(rawBody) as unknown;
+
+      if (parsedBody && typeof parsedBody === "object") {
+        body = parsedBody as { type?: "blog" | "work"; slug?: string };
+      } else {
+        return NextResponse.json(
+          { message: "Invalid JSON body: expected an object" },
+          { status: 400 },
+        );
+      }
+    } catch {
+      return NextResponse.json(
+        { message: "Invalid JSON body" },
+        { status: 400 },
+      );
+    }
+  }
 
   if (body.type && body.slug) {
     const path = body.type === "blog" ? `/blog/${body.slug}` : `/work/${body.slug}`;

--- a/src/components/content-blocks/blocks/media-blocks.tsx
+++ b/src/components/content-blocks/blocks/media-blocks.tsx
@@ -1,14 +1,34 @@
+import { Typography } from "@/components/typography";
 import { withContentValidation } from "@9gustin/react-notion-render";
 import type { DropedProps } from "@9gustin/react-notion-render/dist/hoc/withContentValidation";
 import { CoverImage } from "../../cover-image";
 import { toYouTubeEmbedUrl } from "../utils/to-youtube-embed-url";
 
-export const ImageBlock = withContentValidation((props: DropedProps) => (
-  <CoverImage src={props.media?.src ?? ""} alt={props.media?.alt ?? ""} />
-));
+export const ImageBlock = withContentValidation((props: DropedProps) => {
+  const imageSrc = props.media?.src;
+
+  if (!imageSrc) {
+    return null;
+  }
+
+  return <CoverImage src={imageSrc} alt={props.media?.alt ?? ""} />;
+});
 
 export const VideoBlock = withContentValidation((props: DropedProps) => {
   const embedUrl = toYouTubeEmbedUrl(props.media?.src);
+
+  if (!embedUrl) {
+    return (
+      <div
+        className="flex aspect-video w-full items-center justify-center rounded-md border border-border bg-muted px-4 text-center text-sm text-muted-foreground"
+        role="note"
+      >
+        <Typography size="small" className="text-muted-foreground">
+          Video unavailable: invalid YouTube URL.
+        </Typography>
+      </div>
+    );
+  }
 
   return (
     <iframe

--- a/src/components/content-blocks/rich-text.tsx
+++ b/src/components/content-blocks/rich-text.tsx
@@ -71,6 +71,10 @@ export function renderRichTextNode(
     );
   }
 
+  if (!link.startsWith("http://") && !link.startsWith("https://")) {
+    return null;
+  }
+
   return (
     <a
       key={key}

--- a/src/components/heading-page.tsx
+++ b/src/components/heading-page.tsx
@@ -16,7 +16,7 @@ export function HeadingPage({
   return (
     <div className="w-full flex flex-col items-start justify-start gap-5">
       {top}
-      <div className=" w-full flex flex-col items-start justify-start gap-[6px]">
+      <div className="w-full flex flex-col items-start justify-start gap-[6px]">
         <Typography component="h1" variant={size === "small" ? "h2" : "h1"}>
           {title}
         </Typography>

--- a/src/components/project-item.tsx
+++ b/src/components/project-item.tsx
@@ -18,7 +18,7 @@ export function ProjectItem({ post }: ProjectItemProps) {
             src={post.thumbnail}
             alt={post.title}
             width={640}
-            height={424}
+            height={480}
             sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 360px"
             loading="lazy"
             className="aspect-4/3 h-full w-full object-cover"

--- a/src/sections/content.tsx
+++ b/src/sections/content.tsx
@@ -28,21 +28,10 @@ export default function ContentSection({ blocks }: ContentSectionProps) {
       <Render
         blocks={blocks as NotionBlock[]}
         simpleTitles
-        linkAttributes={(link) => {
-          const isInternalLink =
-            link.startsWith(process.env.BASE_URL!) || link.startsWith("/");
-
-          if (isInternalLink) {
-            return {
-              target: "_self",
-            };
-          }
-
-          return {
-            target: "_blank",
-            rel: "noopener noreferrer",
-          };
-        }}
+        linkAttributes={() => ({
+          target: "_blank",
+          rel: "noopener noreferrer",
+        })}
         blockComponentsMapper={{
           [blockEnum.IMAGE]: ImageBlock,
           [blockEnum.HEADING1]: Heading1Block,

--- a/src/services/notion.tsx
+++ b/src/services/notion.tsx
@@ -166,7 +166,24 @@ export async function getAllPublishedSlugsForStaticParams(
   media: keyof typeof mediaMap,
 ): Promise<{ slug: string }[]> {
   const entries = await getAllPublishedEntriesWithTimestamps(databaseId, media);
-  return entries.map(({ slug }) => ({ slug }));
+  const uniqueSlugs = new Set<string>();
+  const duplicateSlugs = new Set<string>();
+
+  for (const { slug } of entries) {
+    if (uniqueSlugs.has(slug)) {
+      duplicateSlugs.add(slug);
+      continue;
+    }
+    uniqueSlugs.add(slug);
+  }
+
+  if (duplicateSlugs.size > 0) {
+    console.warn(
+      `[notion] Duplicate slugs found in "${media}" static params for database ${databaseId}: ${Array.from(duplicateSlugs).join(", ")}`,
+    );
+  }
+
+  return Array.from(uniqueSlugs, (slug) => ({ slug }));
 }
 
 /** Same pages as static params, including `lastModified` from Notion for sitemaps. */


### PR DESCRIPTION
## Summary
- make Notion content pages consume already-formatted blocks directly and deduplicate static slugs to prevent duplicate route generation
- harden rich media/rendering paths by guarding invalid image/video/link inputs and enforcing external link attributes
- make `/api/revalidate` return clear 400 responses for invalid JSON payloads while still handling empty bodies safely

## Test plan
- [x] Run `npm run lint`
- [x] Run `npm run build`
- [x] Manually hit `/api/revalidate` with empty, valid, and invalid JSON bodies
- [x] Verify about/work pages render content and media blocks correctly

Made with [Cursor](https://cursor.com)