### PR TITLE
chore: document cloud dev environment setup and runtime gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,13 @@
 
 Standard commands live in `package.json` scripts and `CLAUDE.md` (`pnpm dev`, `build`, `lint`, `type-check`, `test`). Package manager is `pnpm` (Node 22 is the CI baseline). The update script runs `pnpm install --frozen-lockfile`, so dependencies are already installed when a session starts.
 
+Env vars: the Notion + Supabase secrets (`NOTION_ACCESS_TOKEN`, `NOTION_DATABASE_*`, `NOTION_PAGE_*`, `NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) are provided as injected Cloud-agent secrets, so they are already in `process.env`. The one var that is **not** injected is `BASE_URL` — before running `pnpm dev`, create `.env` (gitignored) with `BASE_URL=http://localhost:3000`, otherwise every route 500s (see below). `.env` values and injected env vars are merged by Next.js.
+
 Non-obvious runtime gotchas:
 
-- The app does **not** degrade gracefully without env vars. Copy `.env.example` to `.env` before running anything that renders a page.
-- `BASE_URL` must be a valid absolute URL: the root layout does `metadataBase: new URL(process.env.BASE_URL!)` at module load, which throws `ERR_INVALID_URL` (HTTP 500 on every route) if it is unset. For local dev set `BASE_URL=http://localhost:3000`.
-- All content comes from a private Notion workspace. With `BASE_URL` set but no/invalid `NOTION_ACCESS_TOKEN` (+ the `NOTION_DATABASE_*`/`NOTION_PAGE_*` IDs), the dev server boots and routes return 200 at the HTTP layer, but content sections throw `401 API token is invalid` and the browser shows a hard "server error" page (no error boundary). Real Notion credentials are required to render or test any page end to end.
-- Reactions use Supabase. `src/lib/supabase.ts` creates the client at module load and throws if `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are missing, so post pages (`/blog/[slug]`, `/work/[slug]`) and `/api/reactions/*` error without those vars. Core index pages do not import it.
+- The app does **not** degrade gracefully without env vars.
+- `BASE_URL` must be a valid absolute URL: the root layout does `metadataBase: new URL(process.env.BASE_URL!)` at module load, which throws `ERR_INVALID_URL` (HTTP 500 on every route) if unset.
+- All content comes from a private Notion workspace. With `BASE_URL` set but an invalid/absent `NOTION_ACCESS_TOKEN`, routes return 200 at the HTTP layer but content sections throw `401 API token is invalid` and the browser shows a hard "server error" page (no error boundary).
+- Reactions use Supabase. `src/lib/supabase.ts` creates the client at module load and throws if `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are missing, so post pages (`/blog/[slug]`, `/work/[slug]`) and `/api/reactions/*` error without those vars. Core index pages do not import it. Posting a like/dislike writes to the real Supabase `post_reactions` table (dedups by session cookie + hashed IP).
 - `pnpm build` calls `generateStaticParams()`, which queries Notion at build time, so a production build also needs valid Notion credentials. Use `pnpm dev` for local work.
 - `pnpm test` (Vitest + jsdom) runs fully offline — coverage excludes app routes and the Notion/Supabase service layers, so no secrets are needed for the test suite, lint, or type-check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,16 @@
 - Repository workflow uses `develop` as the integration/default branch for feature PRs before promotion to `main`.
 - Content block renderers run as server components; avoid client-only hooks like `useEffect` unless explicitly making the component client-side.
 - Published date rendering should prefer Notion datetime values when present and fall back to formatter utilities.
+
+## Cursor Cloud specific instructions
+
+Standard commands live in `package.json` scripts and `CLAUDE.md` (`pnpm dev`, `build`, `lint`, `type-check`, `test`). Package manager is `pnpm` (Node 22 is the CI baseline). The update script runs `pnpm install --frozen-lockfile`, so dependencies are already installed when a session starts.
+
+Non-obvious runtime gotchas:
+
+- The app does **not** degrade gracefully without env vars. Copy `.env.example` to `.env` before running anything that renders a page.
+- `BASE_URL` must be a valid absolute URL: the root layout does `metadataBase: new URL(process.env.BASE_URL!)` at module load, which throws `ERR_INVALID_URL` (HTTP 500 on every route) if it is unset. For local dev set `BASE_URL=http://localhost:3000`.
+- All content comes from a private Notion workspace. With `BASE_URL` set but no/invalid `NOTION_ACCESS_TOKEN` (+ the `NOTION_DATABASE_*`/`NOTION_PAGE_*` IDs), the dev server boots and routes return 200 at the HTTP layer, but content sections throw `401 API token is invalid` and the browser shows a hard "server error" page (no error boundary). Real Notion credentials are required to render or test any page end to end.
+- Reactions use Supabase. `src/lib/supabase.ts` creates the client at module load and throws if `NEXT_PUBLIC_SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are missing, so post pages (`/blog/[slug]`, `/work/[slug]`) and `/api/reactions/*` error without those vars. Core index pages do not import it.
+- `pnpm build` calls `generateStaticParams()`, which queries Notion at build time, so a production build also needs valid Notion credentials. Use `pnpm dev` for local work.
+- `pnpm test` (Vitest + jsdom) runs fully offline — coverage excludes app routes and the Notion/Supabase service layers, so no secrets are needed for the test suite, lint, or type-check.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this Next.js 16 + Notion-CMS personal blog/portfolio and documents the non-obvious runtime gotchas discovered during setup.

- Installed dependencies with `pnpm install --frozen-lockfile` (Node 22, pnpm 10.33.2).
- Verified lint, type-check, and the Vitest suite all pass.
- Verified the `next dev` server boots and serves real Notion content on all routes.
- Verified the Supabase-backed post-reactions feature end-to-end (like → persisted).
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable startup caveats.

The update script (run on VM startup) is `pnpm install --frozen-lockfile`. The Notion + Supabase secrets are injected as Cloud-agent secrets; only `BASE_URL` is set locally in a gitignored `.env` (documented in AGENTS.md).

## Verification

- ✅ `pnpm lint`
- ✅ `pnpm type-check`
- ✅ `pnpm test` — 4 files, 60 tests passed
- ✅ `pnpm dev` — Ready in ~300ms; home renders real "Latest Posts"/"Latest Projects" from Notion; `/`, `/blog`, `/work`, `/gears`, `/about` → 200, unknown path → 404
- ✅ Hello-world action: liked a blog post via the UI → `POST /api/reactions/...` 200 → `likes: 0 → 1` persisted in Supabase

## Walkthrough

Liking a blog post (core interactive feature: client → API route → Supabase → UI update):

[blog_like_reaction_clean.mp4](https://cursor.com/agents/bc-3885782e-43ea-46cf-a1f4-d5685f67dbd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_like_reaction_clean.mp4)

Before (hovering Like, count empty) and after (Like active, count "1"):

[Before clicking like](https://cursor.com/agents/bc-3885782e-43ea-46cf-a1f4-d5685f67dbd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flike_before.webp)
[After clicking like, count shows 1](https://cursor.com/agents/bc-3885782e-43ea-46cf-a1f4-d5685f67dbd2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flike_after.webp)

Note: the brief full-screen cube animation at the very tail of the video is a screen-recorder finalization artifact, not app behavior — the dev-server logs show no navigation and the screenshots captured at that moment show the normal liked page.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3885782e-43ea-46cf-a1f4-d5685f67dbd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3885782e-43ea-46cf-a1f4-d5685f67dbd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

