### PR TITLE
refactor: proxy Purl saves through the public v1 API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,8 +17,9 @@ NEXT_PUBLIC_SUPABASE_URL=value
 SUPABASE_SERVICE_ROLE_KEY=value
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=value
 
-# Purl — bookmark/save-link integration
-NEXT_PUBLIC_PURL_URL=https://purl.nublson.com
+# Purl — bookmark/save-link integration (server-side API proxy)
+PURL_URL=https://purl.nublson.com
+PURL_API_KEY=value
 
 # Reactions — IP-based cross-browser dedup
 # Any random secret string; used to hash visitor IPs before storing them

--- a/src/app/api/purl/links/route.ts
+++ b/src/app/api/purl/links/route.ts
@@ -1,0 +1,53 @@
+import { PurlApiError, savePurlLink } from "@/services/purl";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body || typeof body !== "object") {
+    return NextResponse.json(
+      { error: "Request body must be an object" },
+      { status: 400 },
+    );
+  }
+
+  const { url } = body as Record<string, unknown>;
+
+  if (typeof url !== "string" || url.trim() === "") {
+    return NextResponse.json(
+      { error: "url is required and must be a non-empty string" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    new URL(url);
+  } catch {
+    return NextResponse.json({ error: "url must be a valid URL" }, { status: 400 });
+  }
+
+  try {
+    const link = await savePurlLink(url);
+    return NextResponse.json(link, { status: 201 });
+  } catch (err) {
+    if (err instanceof PurlApiError) {
+      return NextResponse.json(
+        {
+          error: err.body?.error ?? err.message,
+          code: err.body?.code,
+          feature: err.body?.feature,
+        },
+        { status: err.status },
+      );
+    }
+
+    const message =
+      err instanceof Error ? err.message : "Internal server error";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/components/post-reactions.tsx
+++ b/src/components/post-reactions.tsx
@@ -9,8 +9,6 @@ import { Check, Share2, ThumbsDown, ThumbsUp } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { TooltipWrapper } from "./tooltip-wrapper";
 
-const PURL_URL = process.env.NEXT_PUBLIC_PURL_URL ?? "https://purl.nublson.com";
-
 type PurlState = "idle" | "saving" | "saved" | "error";
 
 function PurlLogo({ className }: { className?: string }) {
@@ -215,25 +213,22 @@ export function PostReactions({
     let nextState: PurlState = "saved";
     let nextError: string | null = null;
     try {
-      const res = await fetch(`${PURL_URL}/api/links`, {
+      const res = await fetch("/api/purl/links", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        credentials: "include",
         body: JSON.stringify({ url: window.location.href }),
         signal: controller.signal,
       });
       clearTimeout(timeout);
-      if (res.status === 401) {
-        window.open(`${PURL_URL}/login`, "_blank", "noopener,noreferrer");
-        setPurlState("idle");
-        setPurlError(null);
-        return;
-      } else if (res.status === 402) {
+      if (res.status === 402) {
         nextState = "error";
         nextError = "Link limit reached";
       } else if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         nextState = "error";
-        nextError = "Something went wrong";
+        nextError = body?.error ?? "Something went wrong";
       }
     } catch (e) {
       clearTimeout(timeout);
@@ -241,11 +236,8 @@ export function PostReactions({
         nextState = "error";
         nextError = "Request timed out";
       } else {
-        // Cross-origin network error — server likely blocks CORS for unauthenticated requests
-        window.open(`${PURL_URL}/login`, "_blank", "noopener,noreferrer");
-        setPurlState("idle");
-        setPurlError(null);
-        return;
+        nextState = "error";
+        nextError = "Something went wrong";
       }
     }
     setPurlState(nextState);

--- a/src/services/purl.test.ts
+++ b/src/services/purl.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { savePurlLink } from "./purl";
+
+const mockLink = {
+  id: "clxyz123",
+  url: "https://example.com/article",
+  title: "An interesting article",
+  description: null,
+  favicon: "https://example.com/favicon.ico",
+  thumbnail: null,
+  domain: "example.com",
+  contentType: "WEB" as const,
+  ingestStatus: "PENDING" as const,
+  createdAt: "2025-06-05T12:00:00.000Z",
+};
+
+describe("savePurlLink", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("saves a link via the Purl v1 API", async () => {
+    vi.stubEnv("PURL_API_KEY", "purl_test_key");
+    vi.stubEnv("PURL_URL", "https://purl.nublson.com");
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockLink,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await savePurlLink("https://example.com/article");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://purl.nublson.com/api/v1/links",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bearer purl_test_key",
+        },
+        body: JSON.stringify({ url: "https://example.com/article" }),
+      },
+    );
+    expect(result).toEqual(mockLink);
+  });
+
+  it("throws PurlApiError when the API returns an error", async () => {
+    vi.stubEnv("PURL_API_KEY", "purl_test_key");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 402,
+        json: async () => ({
+          error: "Plan limit reached",
+          code: "LIMIT_REACHED",
+        }),
+      }),
+    );
+
+    await expect(savePurlLink("https://example.com/article")).rejects.toMatchObject({
+      name: "PurlApiError",
+      status: 402,
+      message: "Plan limit reached",
+    });
+  });
+
+  it("throws when PURL_API_KEY is missing", async () => {
+    await expect(savePurlLink("https://example.com/article")).rejects.toThrow(
+      "PURL_API_KEY is not configured",
+    );
+  });
+});

--- a/src/services/purl.ts
+++ b/src/services/purl.ts
@@ -1,0 +1,71 @@
+export type PurlLink = {
+  id: string;
+  url: string;
+  title: string | null;
+  description: string | null;
+  favicon: string | null;
+  thumbnail: string | null;
+  domain: string;
+  contentType: "WEB" | "YOUTUBE" | "PDF" | "AUDIO";
+  ingestStatus: "PENDING" | "COMPLETED";
+  createdAt: string;
+};
+
+export type PurlErrorBody = {
+  error: string;
+  code?: string;
+  feature?: string;
+};
+
+function getPurlApiBase(): string {
+  const base =
+    process.env.PURL_URL ??
+    process.env.NEXT_PUBLIC_PURL_URL ??
+    "https://purl.nublson.com";
+  return `${base.replace(/\/$/, "")}/api/v1`;
+}
+
+function getPurlApiKey(): string {
+  const apiKey = process.env.PURL_API_KEY;
+  if (!apiKey) {
+    throw new Error("PURL_API_KEY is not configured");
+  }
+  return apiKey;
+}
+
+export class PurlApiError extends Error {
+  readonly status: number;
+  readonly body: PurlErrorBody | null;
+
+  constructor(status: number, body: PurlErrorBody | null) {
+    super(body?.error ?? `Purl API request failed (${status})`);
+    this.name = "PurlApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export async function savePurlLink(url: string): Promise<PurlLink> {
+  const res = await fetch(`${getPurlApiBase()}/links`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${getPurlApiKey()}`,
+    },
+    body: JSON.stringify({ url }),
+  });
+
+  const body = (await res.json().catch(() => null)) as
+    | PurlLink
+    | PurlErrorBody
+    | null;
+
+  if (!res.ok) {
+    throw new PurlApiError(
+      res.status,
+      body && "error" in body ? body : null,
+    );
+  }
+
+  return body as PurlLink;
+}


### PR DESCRIPTION
## Summary
- Replace cookie-based Purl saves with a server-side proxy to `POST /api/v1/links`
- Add `PURL_API_KEY` and `PURL_URL` env vars; remove client-side `NEXT_PUBLIC_PURL_URL`
- Forward Purl API errors (e.g. 402 plan limit) to the save button UI

## Test plan
- [x] Set `PURL_API_KEY` in `.env` and restart dev server
- [x] Click "Save on Purl" on a blog/work post and confirm success state
- [x] Verify the link appears in the Purl account tied to the API key
- [x] Run `pnpm vitest run src/services/purl.test.ts`


Made with [Cursor](https://cursor.com)